### PR TITLE
children list may be null (checking and handling)

### DIFF
--- a/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/rest/data/util/ItemUtil.java
+++ b/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/rest/data/util/ItemUtil.java
@@ -52,10 +52,12 @@ public class ItemUtil {
 
 	public static Item gatherNewest(List<Item> items) {
 		Item newest = null;
-		for (Item item : items) {
-			Item localNewest = gatherNewest(item);
-			if (newest == null || updateComparator.compare(localNewest, newest) > 0) {
-				newest = localNewest;
+		if (items != null) {
+			for (Item item : items) {
+				Item localNewest = gatherNewest(item);
+				if (newest == null || updateComparator.compare(localNewest, newest) > 0) {
+					newest = localNewest;
+				}
 			}
 		}
 		return newest;
@@ -68,10 +70,12 @@ public class ItemUtil {
 			if (type == Item.ItemType.aggregation || type == Item.ItemType.uber
 					|| type == Item.ItemType.template) {
 				List<Item> children = item.getChildren();
-				for (Item child : children) {
-					Item newestChild = gatherNewest(child, depth + 1);
-					if (updateComparator.compare(newestChild, item) > 0) {
-						newest = newestChild;
+				if (children != null) {
+					for (Item child : children) {
+						Item newestChild = gatherNewest(child, depth + 1);
+						if (updateComparator.compare(newestChild, item) > 0) {
+							newest = newestChild;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
This should fix the "Item not found" when an item doesn't have children.  Was introduced a while back with caching checks.  We will want to try this out on dev as I have my database in a bit of a mess right now.