### PR TITLE
Layer switching based on zoom

### DIFF
--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/front/Map.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/front/Map.js
@@ -372,6 +372,13 @@ CCH.Objects.Front.Map = function (args) {
 			return layer;
 		},
 		zoomendCallback: function () {
+			var map = me.map;
+			if (map.baseLayer.name.toLowerCase() === "ocean" && map.getZoom() > 13) {
+				var baseLayers = map.getLayersByName("World Imagery");
+				if (baseLayers.length > 0) {
+					map.setBaseLayer(baseLayers[0]);
+				}
+			}
 			CCH.session.updateSession();
 		},
 		moveendCallback: function () {


### PR DESCRIPTION
If user is viewing ocean basemap and zooms in too far, app automatically switches to world imagery