### PR TITLE
USGS Coastal Hazards text refreshes home page until mobile

### DIFF
--- a/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/components/front/navigation-bar.jsp
+++ b/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/components/front/navigation-bar.jsp
@@ -4,9 +4,14 @@
 </a>
 
 <%-- Application Title --%>
+
 <div id="app-navbar-site-title-container" class="app-navbar-item-container">
-    <div class="app-navbar-title visible-lg hidden-md hidden-sm hidden-xs">USGS Coastal Change Hazards Portal</div>
-    <div class="app-navbar-title hidden-lg visible-md hidden-sm hidden-xs">USGS Coastal Change Hazards</div>
+    <a href="${param['baseUrl']}/">
+        <div class="app-navbar-title visible-lg hidden-md hidden-sm hidden-xs">USGS Coastal Change Hazards Portal</div>
+    </a>
+    <a href="${param['baseUrl']}/">
+        <div class="app-navbar-title hidden-lg visible-md hidden-sm hidden-xs">USGS Coastal Change Hazards</div>
+    </a>
     <div class="app-navbar-title hidden-lg hidden-md visible-sm hidden-xs">USGS Coastal Change Hazards</div>
     <div class="app-navbar-title hidden-lg hidden-md hidden-sm visible-xs">&nbsp;</div>
 </div>


### PR DESCRIPTION
Made the two desktop "USGS Coastal Change Hazards Portal" and "USGS Coastal Change Hazards" into links that refresh the home page, just like the logo