### PR TITLE
Centering Error Message

### DIFF
--- a/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/server-error/index.jsp
+++ b/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/server-error/index.jsp
@@ -117,7 +117,7 @@
 		<script type="text/javascript">
 			var errorCode = <%=request.getAttribute("javax.servlet.error.status_code")%>;
 			var errorPath = '<%=request.getAttribute("javax.servlet.error.request_uri")%>';
-			var errorException = '<%=request.getAttribute("javax.servlet.error.exception")%>';
+			var errorException = '<%=request.getAttribute("javax.servlet.error.message")%>';
 			var description = '';
 			var method = '<%=request.getMethod()%>';
 			var contact = {
@@ -128,7 +128,7 @@
 			switch (errorCode) {
 					case 404 :
 					{
-						description = 'Page Not Found At...';
+						description = 'Page Not Found At URL...';
 						contact.content = 'The application could not find the path at ' + errorPath;
 						break;
 					}

--- a/coastal-hazards-portal/src/main/webapp/images/error/error.svg
+++ b/coastal-hazards-portal/src/main/webapp/images/error/error.svg
@@ -2529,7 +2529,7 @@ e+jPi1ZnDNvbFlT3XIEGPqvGRyg4mODx/wDZaot5RmCtp8Cv/9k=">
 	</g>
 	<g id="error-message">
 		<text transform="matrix(1 0 0 1 757.3 750)">
-			<tspan x="0" y="0" fill="#8C1017" font-family="'Arial" font-size="30"></tspan>
+			<tspan x="2.3%" y="0" fill="#8C1017" font-family="'Arial" font-size="30"></tspan>
 			<tspan x="0" y="35" fill="#8C1017" font-family="Arial" font-size="1.35em"></tspan>
 			<tspan id="back-to-portal-link" class="link" x="140" y="120" fill="#8C1017" font-family="Arial, Sans-Serif" font-size="25.252">Back To Portal</tspan>
 			<tspan id="contact-link" class="link" x="160" y="160" fill="#8C1017" font-family="Arial, Sans-Serif" font-size="25.252">Contact Us</tspan>


### PR DESCRIPTION
Tried to get the error message to center with text-align center, but it wouldn't work.

Then tried to use text-anchor="middle",text-anchor="start", and text-anchor="end", but that only adjusts the text based on the beginning letters placement.  For a better explanation than I can give, https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/text-anchor

Finally just adjusted the x on the svg tspan to a point where at least the 500 and 400 error messages appear centered.  Had to add a little more text to the 400 error message to get it to be a closer to the 500 message character count to avoid one being centered and one off too far to the right.

I think this is only a quick fix, as I prefer a fix that would completely center the text no matter how long it is, but I haven't a clue at the moment what that would take.