### PR TITLE
Back of Card Logo works again

### DIFF
--- a/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/server-error/index.jsp
+++ b/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/server-error/index.jsp
@@ -128,7 +128,7 @@
 			switch (errorCode) {
 					case 404 :
 					{
-						description = 'Page Not Found At URL...';
+						description = 'Page Not Found At...';
 						contact.content = 'The application could not find the path at ' + errorPath;
 						break;
 					}

--- a/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/server-error/index.jsp
+++ b/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/server-error/index.jsp
@@ -117,7 +117,7 @@
 		<script type="text/javascript">
 			var errorCode = <%=request.getAttribute("javax.servlet.error.status_code")%>;
 			var errorPath = '<%=request.getAttribute("javax.servlet.error.request_uri")%>';
-			var errorException = '<%=request.getAttribute("javax.servlet.error.exception")%>';
+			var errorException = '<%=request.getAttribute("javax.servlet.error.message")%>';
 			var description = '';
 			var method = '<%=request.getMethod()%>';
 			var contact = {
@@ -128,7 +128,7 @@
 			switch (errorCode) {
 					case 404 :
 					{
-						description = 'Page Not Found At...';
+						description = 'Page Not Found At URL...';
 						contact.content = 'The application could not find the path at ' + errorPath;
 						break;
 					}

--- a/coastal-hazards-portal/src/main/webapp/images/error/error.svg
+++ b/coastal-hazards-portal/src/main/webapp/images/error/error.svg
@@ -2529,7 +2529,7 @@ e+jPi1ZnDNvbFlT3XIEGPqvGRyg4mODx/wDZaot5RmCtp8Cv/9k=">
 	</g>
 	<g id="error-message">
 		<text transform="matrix(1 0 0 1 757.3 750)">
-			<tspan x="2.3%" y="0" fill="#8C1017" font-family="'Arial" font-size="30"></tspan>
+			<tspan x="0" y="0" fill="#8C1017" font-family="'Arial" font-size="30"></tspan>
 			<tspan x="0" y="35" fill="#8C1017" font-family="Arial" font-size="1.35em"></tspan>
 			<tspan id="back-to-portal-link" class="link" x="140" y="120" fill="#8C1017" font-family="Arial, Sans-Serif" font-size="25.252">Back To Portal</tspan>
 			<tspan id="contact-link" class="link" x="160" y="160" fill="#8C1017" font-family="Arial, Sans-Serif" font-size="25.252">Contact Us</tspan>

--- a/coastal-hazards-portal/src/main/webapp/images/error/error.svg
+++ b/coastal-hazards-portal/src/main/webapp/images/error/error.svg
@@ -2529,7 +2529,7 @@ e+jPi1ZnDNvbFlT3XIEGPqvGRyg4mODx/wDZaot5RmCtp8Cv/9k=">
 	</g>
 	<g id="error-message">
 		<text transform="matrix(1 0 0 1 757.3 750)">
-			<tspan x="0" y="0" fill="#8C1017" font-family="'Arial" font-size="30"></tspan>
+			<tspan x="2.3%" y="0" fill="#8C1017" font-family="'Arial" font-size="30"></tspan>
 			<tspan x="0" y="35" fill="#8C1017" font-family="Arial" font-size="1.35em"></tspan>
 			<tspan id="back-to-portal-link" class="link" x="140" y="120" fill="#8C1017" font-family="Arial, Sans-Serif" font-size="25.252">Back To Portal</tspan>
 			<tspan id="contact-link" class="link" x="160" y="160" fill="#8C1017" font-family="Arial, Sans-Serif" font-size="25.252">Contact Us</tspan>

--- a/coastal-hazards-portal/src/main/webapp/js/application/back/OnReady.js
+++ b/coastal-hazards-portal/src/main/webapp/js/application/back/OnReady.js
@@ -17,6 +17,10 @@ $(document).ready(function () {
 	CCH.ows = new CCH.Util.OWS();
 	
 	CCH.session = new CCH.Objects.Session();
+        
+        $('#app-navbar-coop-logo-img').on('click', function () {
+            window.location.href = CCH.CONFIG.contextPath;
+        });
 		
 	// I am loading an item with the full subtree so once that item is loaded, start loading the rest of the application
 	$(window).on('cch.item.loaded', function (evt, args) {


### PR DESCRIPTION
Deleted a function 4 days ago that had the header-row as a anchor to go back to the home map page, found out I had completely stopped the go back function from the logo doing that.  Returned the function and adjusted it to only let the logo take you back as requested