### PR TITLE
sash 4.0 and breadcrumb text size

### DIFF
--- a/coastal-hazards-portal/src/main/webapp/less/front/slider-items.less
+++ b/coastal-hazards-portal/src/main/webapp/less/front/slider-items.less
@@ -466,6 +466,10 @@
 	.corner-ribbon p{
 		margin:0 0 0 50px;
 	}
+        
+        .application-card-breadcrumbs-container{
+            font-size:16px;
+        }
 
 }
 
@@ -479,10 +483,10 @@
     .application-card-title-row .application-card-title-container-medium {
 	font-size: 14px;
     }
-
+    
     .corner-ribbon-wrapper{
         width:75px;
-        height:44px;
+        height:50px;
     }
 
     .corner-ribbon{
@@ -494,6 +498,6 @@
 
     .corner-ribbon p{
         width:90px;
-        margin:0 0 0 6px;
+        margin:0 0 0 7px;
     }
 }


### PR DESCRIPTION
The mobile top level buttons grew in height again somehow so the sash had to be made longer to match, also made the breadcrumb text from 13px to 16px.