### PR TITLE
Refactoring head/get download requests and staging

### DIFF
--- a/coastal-hazards-export/src/main/java/gov/usgs/cida/coastalhazards/export/HttpComponentsWFSClient.java
+++ b/coastal-hazards-export/src/main/java/gov/usgs/cida/coastalhazards/export/HttpComponentsWFSClient.java
@@ -51,7 +51,7 @@ public class HttpComponentsWFSClient implements WFSClientInterface {
 
     @Override
     public SimpleFeatureCollection getFeatureCollection(String typeName, Filter filter) throws IOException {
-        SimpleFeatureCollection collection= null;
+        SimpleFeatureCollection collection;
         
         String filterXml = null;
         InputStream is = null;

--- a/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/download/DownloadUtility.java
+++ b/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/download/DownloadUtility.java
@@ -73,12 +73,26 @@ public class DownloadUtility {
 		}
 	}
 
+	/**
+	 * Find where there staging directory is located for all download items.
+	 * Will first attempt to read the location from JNDI propertes. Will fall
+	 * back to the Java system property "java.io.tmpdir"
+	 *
+	 * @return the staging file location
+	 */
 	public static File getStagingParentDir() {
 		String downloadDir = JNDISingleton.getInstance().getProperty("coastal-hazards.files.directory.download",
 				System.getProperty("java.io.tmpdir"));
 		return new File(downloadDir);
 	}
 
+	/**
+	 * Creates a unique area within the staging directory and returns the
+	 * location
+	 *
+	 * @return a path to the staging area
+	 * @throws IOException
+	 */
 	public static File createDownloadStagingArea() throws IOException {
 		File stagingParentDir = getStagingParentDir();
 		UUID uuid = UUID.randomUUID();
@@ -120,7 +134,7 @@ public class DownloadUtility {
 			populateDownloadMap(downloadMap, stageThis);
 
 			if (downloadMap.isEmpty()) {
-				LOG.info("Could not find valid WFS for item {}", itemId);
+				LOG.info("Could not find valid WFS for item {}. Will add to missing list", itemId);
 				missing.add(stageThis.getName());
 			} else {
 				List<String> namesUsed = new ArrayList<>(downloadMap.values().size());
@@ -133,6 +147,7 @@ public class DownloadUtility {
 
 					// TODO try/catch this to isolate/retry problem downloads
 					success = stagedDownload.stage(stagingDir, missing);
+					LOG.info("Download staged for {}", stagedDownload.getName());
 				}
 			}
 		} finally {
@@ -324,36 +339,49 @@ public class DownloadUtility {
 
 		@Override
 		public Download call() throws IOException {
-			Download download = null;
 			File stagingDir = DownloadUtility.createDownloadStagingArea();
 			LOG.info("Staging item download at location {} for item {}", stagingDir.getAbsolutePath(), itemId);
 
-			try (ItemManager itemManager = new ItemManager(); DownloadManager downloadManager = new DownloadManager()) {
-				Item item = itemManager.load(itemId);
-				if (item == null) {
-					throw new IOException(MessageFormat.format("Item {0} does not exist", itemId));
-				}
+			Item item;
+			try (ItemManager itemManager = new ItemManager()) {
+				item = itemManager.load(itemId);
+			}
+
+			if (item == null) {
+				throw new IOException(MessageFormat.format("Item {0} does not exist", itemId));
+			}
+
+			Download download;
+			try (DownloadManager downloadManager = new DownloadManager()) {
 				download = downloadManager.load(itemId);
 				if (download == null) {
-					LOG.debug("Beginning staging item {}", itemId);
+					LOG.info("Beginning staging item {}", itemId);
 					download = new Download();
 					download.setItemId(itemId);
 					downloadManager.save(download);
 				}
-				boolean staged = DownloadUtility.stageItemDownload(item, stagingDir);
-				if (staged) {
-					LOG.info("{} has been staged", itemId);
-					download = DownloadUtility.zipStagingAreaForDownload(stagingDir, download);
-					downloadManager.update(download);
-				} else {
-					LOG.warn("Staging item {} has run into a problem.", itemId);
-					download.setProblem(true);
-					downloadManager.update(download);
-				}
-			} catch (IOException ioe) {
-				LOG.warn("Download could not be staged", ioe);
-				FileUtils.forceDelete(stagingDir);
 			}
+
+			boolean staged = DownloadUtility.stageItemDownload(item, stagingDir);
+
+			if (staged) {
+				LOG.info("Item {} has been staged", itemId);
+				try {
+					download = DownloadUtility.zipStagingAreaForDownload(stagingDir, download);
+				} catch (IOException ioe) {
+					LOG.warn("Download could not be staged", ioe);
+					FileUtils.forceDelete(stagingDir);
+					download.setProblem(true);
+				}
+			} else {
+				LOG.warn("Staging item {} has run into a problem.", itemId);
+				download.setProblem(true);
+			}
+
+			try (DownloadManager downloadManager = new DownloadManager()) {
+				downloadManager.update(download);
+			}
+
 			return download;
 		}
 	}

--- a/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/rest/data/DownloadResource.java
+++ b/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/rest/data/DownloadResource.java
@@ -60,45 +60,59 @@ public class DownloadResource {
 	@Path("/item/{id}")
 	public Response checkItemAvailability(@PathParam("id") String id) throws IOException {
 		Response response;
+		
+		Item item;
+		try (ItemManager itemManager = new ItemManager()) {
+			item = itemManager.load(id);
+		}
+		
+		if (item == null) {
+			response = Response.status(NOT_FOUND).build();
+		} else {
+			Download download;
+			
+			try (DownloadManager downloadManager = new DownloadManager()) {
+				download = downloadManager.load(id);
+			}
+			
+			if (download != null) {
+				LOG.debug("Download manager found a download for item id {}", id);
+				String persistenceURI = download.getPersistanceURI();
 
-		try (ItemManager itemManager = new ItemManager(); DownloadManager downloadManager = new DownloadManager()) {
-			Item item = itemManager.load(id);
-			if (item == null) {
-				response = Response.status(NOT_FOUND).build();
-			} else {
-				Download download = downloadManager.load(id);
-				if (download != null) {
-					LOG.debug("Download manager found a download for item id {}", id);
-					String persistenceURI = download.getPersistanceURI();
-
-					// Check if the file location in the database 
-					// If it is null or blank, the download has been accepted
-					if (download.isProblem()) {
-						LOG.debug("Download manager found a problem with download for item id {}", id);
-						response = Response.status(INTERNAL_SERVER_ERROR).build();
-					} else if (StringUtils.isBlank(persistenceURI)) {
-						LOG.debug("Download manager found a download with no path id {}, Item is probably still being created", id);
+				// Check if the file location in the database 
+				// If it is null or blank, the download has been accepted
+				if (download.isProblem()) {
+					LOG.debug("Download manager found a problem with download for item id {}", id);
+					response = Response.status(INTERNAL_SERVER_ERROR).build();
+				} else if (StringUtils.isBlank(persistenceURI)) {
+					LOG.debug("Download manager found a download with no path id {}, Item is probably still being created", id);
+					response = Response.status(ACCEPTED).build();
+				} else {
+					// If it is has content, check whether the file exists on the server
+					// If it does not, that means this is a desynchronized entry in the datbase
+					// and it should be deleted and reinitialized. Otherwise, this is 
+					// is good to go and send an OK response
+					boolean existsOnFileSystem;
+					
+					try (DownloadManager downloadManager = new DownloadManager()) {
+						existsOnFileSystem = downloadManager.downloadFileExistsOnFilesystem(download);
+					}
+					
+					if (!existsOnFileSystem) {
+						LOG.debug("Download manager found a download path that doesn't exist for id {}. Will delete and re-stage", id);
+						new DownloadService().delete(id);
+						LOG.debug("Download path for item {} was deleted in the database. Will not attempt to re-stage", id);
+						DownloadUtility.stageAsyncItemDownload(id);
 						response = Response.status(ACCEPTED).build();
 					} else {
-						// If it is has content, check whether the file exists on the server
-						// If it does not, that means this is a desynchronized entry in the datbase
-						// and it should be deleted and reinitialized. Otherwise, this is 
-						// is good to go and send an OK response
-						if (!downloadManager.downloadFileExistsOnFilesystem(download)) {
-							LOG.debug("Download manager found a download path that doesn't exist for id {}. Will delete and re-stage", id);
-							new DownloadService().delete(id);
-							DownloadUtility.stageAsyncItemDownload(id);
-							response = Response.status(ACCEPTED).build();
-						} else {
-							LOG.debug("Download manager found the download for item {}", id);
-							response = Response.status(OK).build();
-						}
+						LOG.debug("Download manager found the download for item {}", id);
+						response = Response.status(OK).build();
 					}
-				} else {
-					LOG.debug("Download manager could not find download for item {}. A download will be staged for this item.", id);
-					DownloadUtility.stageAsyncItemDownload(id);
-					response = Response.status(ACCEPTED).build();
 				}
+			} else {
+				LOG.debug("Download manager could not find download for item {}. A download will be staged for this item.", id);
+				DownloadUtility.stageAsyncItemDownload(id);
+				response = Response.status(ACCEPTED).build();
 			}
 		}
 
@@ -119,68 +133,63 @@ public class DownloadResource {
 	@Path("/item/{id}")
 	@Produces("application/zip")
 	public Response downloadItem(@PathParam("id") String id) throws IOException, InterruptedException, ExecutionException {
-		Response response = null;
-		try (ItemManager itemManager = new ItemManager(); DownloadManager downloadManager = new DownloadManager()) {
-			Item item = itemManager.load(id);
-			if (item == null) {
-				response = Response.status(NOT_FOUND).build();
-			} else {
-				File zipFile = null;
-				Download download = downloadManager.load(id);
-
-				if (download != null) {
-					LOG.debug("Download manager found a download for item id {}", id);
-					String persistenceURI = download.getPersistanceURI();
-					if (download.isProblem()) {
-						LOG.debug("Download manager found a problem with download for item id {}", id);
-						response = Response.status(NOT_IMPLEMENTED).build();
-					} else if (StringUtils.isBlank(persistenceURI)) {
-						LOG.debug("Download manager found a download with no path id {}, Item is probably still being created", id);
-						// Download is still being created
+		Response response;
+		Item item;
+		
+		try (ItemManager itemManager = new ItemManager()) {
+			item = itemManager.load(id);
+		}
+		
+		if (item == null) {
+			response = Response.status(NOT_FOUND).build();
+		} else {
+			Download download;
+			try (DownloadManager downloadManager = new DownloadManager()) {
+				download = downloadManager.load(id);
+			}
+			
+			if (download != null) {
+				LOG.debug("Download manager found a download for item id {}", id);
+				if (download.isProblem()) {
+					LOG.debug("Download manager found a problem with download for item id {}", id);
+					response = Response.status(NOT_IMPLEMENTED).build();
+				} else if (StringUtils.isBlank(download.getPersistanceURI())) {
+					LOG.debug("Download manager found a download with no path id {}, Item is still being created", id);
+					response = Response.status(ACCEPTED).build();
+				} else {
+					boolean downloadFileExists;
+					try (DownloadManager downloadManager = new DownloadManager()) {
+						downloadFileExists = downloadManager.downloadFileExistsOnFilesystem(download);
+					}
+					
+					// Download should be on the file system. Check that it does exist
+					if (!downloadFileExists) {
+						LOG.debug("Download manager found a download path that doesn't exist for id {}. Will delete and re-stage", id);
+						new DownloadService().delete(id);
+						DownloadUtility.stageAsyncItemDownload(id);
 						response = Response.status(ACCEPTED).build();
 					} else {
-						// Download should be on the file system. Check that it does exist
-						if (!downloadManager.downloadFileExistsOnFilesystem(download)) {
-							LOG.debug("Download manager found a download path that doesn't exist for id {}. Will delete and re-stage", id);
-							// File is not actually on the file system. Re-stage.
+						// File was found. Load the zip file 
+						File zipFile = download.fetchZipFile();
+						if (zipFile == null) {
+							LOG.debug("Download manager found could not find the zip file that was indicated in the database for item {}. Will attempt to re-stage", id);
 							new DownloadService().delete(id);
 							DownloadUtility.stageAsyncItemDownload(id);
 							response = Response.status(ACCEPTED).build();
 						} else {
-							// File was found. Load the zip file 
-							zipFile = download.fetchZipFile();
-							if (zipFile == null) {
-								LOG.debug("Download manager found could not find the zip file that was indicated in the database for item {}. Will attempt to re-stage", id);
-								new DownloadService().delete(id);
-								DownloadUtility.stageAsyncItemDownload(id);
-								response = Response.status(INTERNAL_SERVER_ERROR).entity("Problem getting persisted download").build();
-							}
+							String contentDisposition = "attachment; filename=\"" + id + ".zip\"";
+							response = Response.status(OK).entity(zipFile).type("application/zip").header("Content-Disposition", contentDisposition).build();
 						}
 					}
-				} else {
-					// Download was null, so we it was not previously staged. Do so now
-					// and wait for it to finish, grabbing the zip file at the end
-					LOG.debug("Download manager could not find download for item {}. A download will be staged for this item.", id);
-					Future<Download> future = DownloadUtility.stageAsyncItemDownload(id);
-					download = future.get();
-					if (download.isProblem()) {
-						LOG.debug("Download manager found a problem with download for item id {}", id);
-						response = Response.status(INTERNAL_SERVER_ERROR).entity("Problem getting persisted download").build();
-					}
-
-					zipFile = download.fetchZipFile();
-					if (zipFile == null) {
-						LOG.debug("Download manager found could not find the zip file that was indicated in the database for item {}.", id);
-						response = Response.status(INTERNAL_SERVER_ERROR).entity("Problem getting persisted download").build();
-					}
 				}
-
-				if (zipFile != null) {
-					String contentDisposition = "attachment; filename=\"" + id + ".zip\"";
-					response = Response.status(OK).entity(zipFile).type("application/zip").header("Content-Disposition", contentDisposition).build();
-				}
+			} else {
+				// Download was null, so we it was not previously staged. Do so now.
+				LOG.debug("Download manager could not find download for item {}. A download will be staged for this item.", id);
+				DownloadUtility.stageAsyncItemDownload(id);
+				response = Response.status(ACCEPTED).build();
 			}
 		}
+		
 		return response;
 	}
 


### PR DESCRIPTION
Trying to isolate try-with-resources blocks only to where they're needed in an attempt to shorten open db connections