### PR TITLE
Updated file- removed ssl-dev not working yet - dependency ‘openssl’ …

### DIFF
--- a/coastal-hazards-n52/src/main/resources/docker/rserve/Dockerfile
+++ b/coastal-hazards-n52/src/main/resources/docker/rserve/Dockerfile
@@ -4,9 +4,8 @@ MAINTAINER Jordan Walker <jiwalker@usgs.gov>
 
 USER root
 RUN apt-get update && \
-    apt-get install -y --force-yes git libssl1.0.0 libssl-dev libcurl3 libcurl3-gnutls libcurl4-openssl-dev libxml2-dev
+    apt-get install -y --force-yes git libcurl3 libcurl3-gnutls libcurl4-openssl-dev libxml2-dev
 
-RUN install.r devtools
-RUN R -e 'library(devtools); install_github("USGS-R/hazarditems");'
+RUN R -e 'install.packages("hazardItems", repos=c("http://owi.usgs.gov/R", "http://cran.us.r-project.org/"));'
 
 USER rserve


### PR DESCRIPTION
…is not available for package ‘httr’