### PR TITLE
Adding units to AE raster identify popup.

### DIFF
--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/LayerIdentifyControl.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/LayerIdentifyControl.js
@@ -452,8 +452,11 @@ return {
 				attrAvg /= incomingFeatureCount;
 				if (["TIDERISK", "SLOPERISK", "ERRRISK", "SLRISK", "GEOM", "WAVERISK", "CVIRISK", "AE"].indexOf(item.attr.toUpperCase()) !== -1) {
 					attrAvg = Math.ceil(attrAvg);
-					category = sld.bins[attrAvg - 1].category;
 					color = sld.bins[attrAvg - 1].color;
+					category = sld.bins[attrAvg - 1].category;
+					if("AE" === item.attr.toUpperCase()){
+						category +=  units;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This is a hack for the AE raster data set. No other raster data in the system displays the same characteristics (raster values used as an index into a category). If other datasets begin doing the same thing we should consider generalizing the solution.