### PR TITLE
Cchs 258

### DIFF
--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/LayerIdentifyControl.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/LayerIdentifyControl.js
@@ -59,7 +59,6 @@ CCH.Objects.LayerIdentifyControl = OpenLayers.Class(OpenLayers.Control.WMSGetFea
 		var tile = tileData.tile;
 		var ctx = tile.getCanvasContext();
 		
-		//order of i and j might be wrong:
 		var color = getCanvasPixelColor(i, j, ctx);
 		
 		return color;

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/LayerIdentifyControl.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/LayerIdentifyControl.js
@@ -71,7 +71,7 @@ CCH.Objects.LayerIdentifyControl = OpenLayers.Class(OpenLayers.Control.WMSGetFea
 		// html canvas context api for getImageData expects following order of args:
 		// (x, y, width, height)
 		var rgba = canvasContext.getImageData(x, y, 1, 1).data;
-		var strRgba = "rgba(" + rgba.join(rgba, ',') + ")";
+		var strRgba = "rgba(" + rgba.join(',') + ")";
 		return strRgba;
 	};
 	

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/LayerIdentifyControl.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/LayerIdentifyControl.js
@@ -28,37 +28,6 @@ CCH.Objects.LayerIdentifyControl = OpenLayers.Class(OpenLayers.Control.WMSGetFea
 		}
 		return overrideName;
 	};	
-	/**
-	 * 
-	 * @param {Array<Object>} bins
-	 * @param {Number} attrAvg
-	 * @returns {String} css-compatible color
-	 */
-	var getBinColorForValue = function(bins, attrAvg){
-		var color = '',
-			binIdx,
-			lb,
-			ub;
-		for (binIdx = 0; binIdx < bins.length && !color; binIdx++) {
-			lb = bins[binIdx].lowerBound;
-			ub = bins[binIdx].upperBound;
-			if (lb !== undefined && ub !== undefined) {
-				if (attrAvg <= ub && attrAvg >= lb) {
-					color = bins[binIdx].color;
-				}
-			} else if (lb === undefined && ub !== undefined) {
-				if (attrAvg <= ub) {
-					color = bins[binIdx].color;
-				}
-			} else {
-				if (attrAvg >= lb) {
-					color = bins[binIdx].color;
-				}
-			}
-		}
-
-		return color;
-	};
 	
 	/**
 	 * @param {Number} x the 'x' coordinate of the desired pixel
@@ -367,9 +336,6 @@ return {
 					}
 				
 				} else {
-					if(!color){
-						color = getBinColorForValue(bins, attrAvg);
-					}
 					
 					$titleContainer.html(title);
 					


### PR DESCRIPTION
This pull request changes the way that we determine the color swatch in the identify balloon.

Prior to this work, the status quo for determining the color swatch in the identify balloon was to first examine the domain value (probability of collision, likelihood of coastal response. etc.) under the click.  Then we picked a bin by iterating through the bins of the item's SLD Info, stopping at the bin that contained the domain value. We used the bin's color property as the color for the swatch in the identify balloon.

This pull request eliminates that approach in favor of using the color of the layer's pixel underneath the click. This was manually tested when 0, 1, or more raster layers were active.

It is still useful for the client to request the SLDInfo for the binned items, because it still needs information on how to map the domain value under the click to a textual category.