### PR TITLE
Forcing tile render on click-to-identify

### DIFF
--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/LayerIdentifyControl.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/LayerIdentifyControl.js
@@ -57,6 +57,9 @@ CCH.Objects.LayerIdentifyControl = OpenLayers.Class(OpenLayers.Control.WMSGetFea
 		var i = tileData.i;
 		var j = tileData.j;
 		var tile = tileData.tile;
+		if(!tile.imgDiv){
+			tile.renderTile();
+		}
 		var ctx = tile.getCanvasContext();
 		
 		var color = getCanvasPixelColor(i, j, ctx);


### PR DESCRIPTION
Forcing tile render on click to identify. This eliminates errors due to uninitialized canvas contexts. This should fix errors occurring with historical shoreline positions, and shoreline change rates.