### PR TITLE
CCHS-225-touch-ups

### DIFF
--- a/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/rest/data/LayerResource.java
+++ b/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/rest/data/LayerResource.java
@@ -146,7 +146,7 @@ public class LayerResource {
         @POST
 	@Path("/raster")
 	@Consumes(MediaType.MULTIPART_FORM_DATA)
-	@Produces(MediaType.APPLICATION_JSON)
+	@Produces(MediaType.TEXT_PLAIN)
 	@RolesAllowed({CoastalHazardsTokenBasedSecurityFilter.CCH_ADMIN_ROLE})
 	public Response createRasterLayer(
                 @Context HttpServletRequest req, 

--- a/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/rest/data/LayerResource.java
+++ b/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/rest/data/LayerResource.java
@@ -146,7 +146,7 @@ public class LayerResource {
         @POST
 	@Path("/raster")
 	@Consumes(MediaType.MULTIPART_FORM_DATA)
-	@Produces(MediaType.TEXT_PLAIN)
+	@Produces(MediaType.APPLICATION_JSON)
 	@RolesAllowed({CoastalHazardsTokenBasedSecurityFilter.CCH_ADMIN_ROLE})
 	public Response createRasterLayer(
                 @Context HttpServletRequest req, 
@@ -175,9 +175,14 @@ public class LayerResource {
                 services.add(MetadataUtil.makeCSWServiceForUrl(MetadataUtil.getMetadataByIdUrl(metadataId)));
 
                 Bbox bbox = MetadataUtil.getBoundingBoxFromFgdcMetadata(metadata);
+                log.info("Starting CRS Identifier Lookup");
+                long startTime = System.nanoTime();
                 String EPSGcode = CRS.lookupIdentifier(MetadataUtil.getCrsFromFgdcMetadata(metadata), true);
+                long endTime = System.nanoTime();
+                long duration = (endTime - startTime)/1000000;  //divide by 1000000 to get milliseconds
+                log.info("Finished CRS Identifier Lookup. Took " + duration + "ms.");
                 
-                if (bbox == null || EPSGcode == null) {
+               if (bbox == null || EPSGcode == null) {
                     throw new ServerErrorException("Unable to identify bbox or epsg code from metadata.", Status.INTERNAL_SERVER_ERROR);
                 }
                 
@@ -186,8 +191,11 @@ public class LayerResource {
                 log.info("Raster layer create - about to addRasterLayer to geoserver with an EPSG of: " + EPSGcode);
                 
                 Service rasterService = GeoserverUtil.addRasterLayer(geoserverEndpoint, zipFileStream, newId, bbox, EPSGcode);
-               
-                services.add(rasterService);
+                if(null == rasterService) {
+                        throw new ServerErrorException("Unable to create a store and/or layer in GeoServer.", Status.INTERNAL_SERVER_ERROR);
+                } else {
+                        services.add(rasterService);
+                }
                 
                 if (!services.isEmpty()) {
 			Layer layer = new Layer();

--- a/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/rest/data/util/GeoserverUtil.java
+++ b/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/rest/data/util/GeoserverUtil.java
@@ -54,7 +54,6 @@ public class GeoserverUtil {
 	// TODO move these centrally or into configuration
 	private static final String PROXY_STORE = "proxied";
         private static final String PROXY_WORKSPACE = "proxied";
-	private static final String PORTAL_WORKSPACE = "portal";
         private static final String DEFAULT_RASTER_STYLE = "raster";
 
 	static {
@@ -366,7 +365,7 @@ public class GeoserverUtil {
                         layerEncoder.setDefaultStyle(DEFAULT_RASTER_STYLE);
                 
                     // Geoserver Manager BUG Alert for v2.4 ...Creating a GeoTIFF coverage via REST works if the coverage's name is the same as the store name, but fails otherwise. Setting nativeName or nativeCoverageName does not help. Changing the name after creating the coverage works fine.    
-                    RESTCoverageStore store = publisher.publishExternalGeoTIFF(PORTAL_WORKSPACE, fileName, unzippedFile, coverageEncoder, layerEncoder); // #TODO# what to do if the workspace:fileName is already in use?
+                    RESTCoverageStore store = publisher.publishExternalGeoTIFF(PROXY_WORKSPACE, fileName, unzippedFile, coverageEncoder, layerEncoder); // #TODO# what to do if the workspace:fileName is already in use?
                     if (null == store) {
                             //if store or layer creation failed
                             log.info("Error publishing GeoTiff in GeoServer.");
@@ -374,7 +373,7 @@ public class GeoserverUtil {
                     } else {
                             log.info("Published GeoTiff!!!");
                             log.info("In GeoserverUtil, about to add wmsService with layer name: " + layerId);
-                            rasterService = wmsService(layerId);
+                            rasterService = wmsService(fileName);
                             log.info("Added layer to wms service.");
                     }
                     return rasterService;

--- a/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/rest/data/util/GeoserverUtil.java
+++ b/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/rest/data/util/GeoserverUtil.java
@@ -79,7 +79,7 @@ public class GeoserverUtil {
 
 			if (StringUtils.isNotBlank(created)) {
 				serviceList.add(wfsService(created));
-				serviceList.add(wmsService(created, PROXY_WORKSPACE));
+				serviceList.add(wmsService(created));
 			}
 		}
 		catch (FileNotFoundException ex) {
@@ -114,9 +114,9 @@ public class GeoserverUtil {
 	 * @param layer
 	 * @return Service with a www-accessible url
 	 */
-	private static Service wmsService(String layer, String workspace) {
+	private static Service wmsService(String layer) {
 		Service service = new Service();
-		URI uri = UriBuilder.fromUri(geoserverExternalEndpoint).path(workspace).path("wms").build();
+		URI uri = UriBuilder.fromUri(geoserverExternalEndpoint).path(PROXY_WORKSPACE).path("wms").build();
 		service.setType(Service.ServiceType.proxy_wms);
 		service.setEndpoint(uri.toString());
 		service.setServiceParameter(layer);
@@ -374,7 +374,7 @@ public class GeoserverUtil {
                     } else {
                             log.info("Published GeoTiff!!!");
                             log.info("In GeoserverUtil, about to add wmsService with layer name: " + layerId);
-                            rasterService = wmsService(fileName, PORTAL_WORKSPACE);
+                            rasterService = wmsService(layerId);
                             log.info("Added layer to wms service.");
                     }
                     return rasterService;

--- a/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/rest/data/util/GeoserverUtil.java
+++ b/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/rest/data/util/GeoserverUtil.java
@@ -79,7 +79,7 @@ public class GeoserverUtil {
 
 			if (StringUtils.isNotBlank(created)) {
 				serviceList.add(wfsService(created));
-				serviceList.add(wmsService(created));
+				serviceList.add(wmsService(created, PROXY_WORKSPACE));
 			}
 		}
 		catch (FileNotFoundException ex) {
@@ -114,9 +114,9 @@ public class GeoserverUtil {
 	 * @param layer
 	 * @return Service with a www-accessible url
 	 */
-	private static Service wmsService(String layer) {
+	private static Service wmsService(String layer, String workspace) {
 		Service service = new Service();
-		URI uri = UriBuilder.fromUri(geoserverExternalEndpoint).path(PROXY_WORKSPACE).path("wms").build();
+		URI uri = UriBuilder.fromUri(geoserverExternalEndpoint).path(workspace).path("wms").build();
 		service.setType(Service.ServiceType.proxy_wms);
 		service.setEndpoint(uri.toString());
 		service.setServiceParameter(layer);
@@ -374,7 +374,7 @@ public class GeoserverUtil {
                     } else {
                             log.info("Published GeoTiff!!!");
                             log.info("In GeoserverUtil, about to add wmsService with layer name: " + layerId);
-                            rasterService = wmsService(layerId);
+                            rasterService = wmsService(fileName, PORTAL_WORKSPACE);
                             log.info("Added layer to wms service.");
                     }
                     return rasterService;

--- a/coastal-hazards-wps/src/main/java/gov/usgs/cida/coastalhazards/wps/FetchAndUnzipProcess.java
+++ b/coastal-hazards-wps/src/main/java/gov/usgs/cida/coastalhazards/wps/FetchAndUnzipProcess.java
@@ -130,7 +130,13 @@ public class FetchAndUnzipProcess implements GeoServerProcess {
                     FileOutputStream fos = null;
                     try{
                         fos = new FileOutputStream(unzippedFile);
+                        long start = System.nanoTime();
+                        LOGGER.info("Starting to unzip the zipped stream to local disk");
                         IOUtils.copyLarge(zipStream, fos);
+                        long end = System.nanoTime();
+                        long duration = (end - start) / 1000000; //duration in ms
+                        LOGGER.info("Finished unzipping the zipped stream to local disk. Duration: " + duration +" ms");
+                        
                     } catch (FileNotFoundException ex) {
                         throw new ProcessException("Error finding file '" + entryFileAbsolutePath + "'.", ex);
                     } catch (IOException ex) {

--- a/coastal-hazards-wps/src/test/java/gov/usgs/cida/coastalhazards/wps/FetchAndUnzipProcessTest.java
+++ b/coastal-hazards-wps/src/test/java/gov/usgs/cida/coastalhazards/wps/FetchAndUnzipProcessTest.java
@@ -3,8 +3,11 @@ package gov.usgs.cida.coastalhazards.wps;
 import gov.usgs.cida.config.DynamicReadOnlyProperties;
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.StringWriter;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -135,50 +138,24 @@ public class FetchAndUnzipProcessTest {
         }
         return; //No Exceptions were thrown on any HTTP status codes
     }
-    /**
-     * Convenience method for returning a sorted list of absolute paths, built from a shared base and several relative paths
-     * @param zipDestination
-     * @param relativePaths
-     * @return 
-     */
-    private List<String> buildExpectedAbsolutePaths(File zipDestination, String ... relativePaths){
-        List<String> expectedPaths = new ArrayList<>();
-        for(String relativePath : relativePaths){
-            expectedPaths.add(new File(zipDestination, relativePath).getAbsolutePath());
-        }
-        Collections.sort(expectedPaths);
-        return expectedPaths;
-    }
-    /**
-     * 
-     * @param zipFileResourcePath the classLoader.getResource()-style path to a zip file
-     * @param expectedRelativePaths The paths that should be found after unzipping
-     */
-    public void assertZipFileUnzipsToPaths(String zipFileResourcePath, String... expectedRelativePaths){
-        InputStream file = this.getClass().getClassLoader().getResourceAsStream(zipFileResourcePath);
-        ZipInputStream zipStream = new ZipInputStream(file);
-        File zipDestination = instance.getNewZipDestination();
-        List<String> expectedPaths = buildExpectedAbsolutePaths(zipDestination, expectedRelativePaths);
-        String expPath = expectedPaths.get(0);
-        String actualPath = instance.unzipToDir(zipStream,zipDestination);
-        assertEquals(expPath, actualPath);
-    }
-    
-   
+
     /**
      * Test of unzipToDir method, of class FetchAndUnzipProcess.
      */
     @Test
-    public void testUnzipSingleFileZipToDir() {       
+    public void testUnzipSingleFileZipToDir() throws FileNotFoundException, IOException {
         String zipFileResourcePath = "gov/usgs/cida/coastalhazards/wps/oneFile.zip";
 
         InputStream file = this.getClass().getClassLoader().getResourceAsStream(zipFileResourcePath);
         ZipInputStream zipStream = new ZipInputStream(file);
         File zipDestination = instance.getNewZipDestination();
         File actualFile = instance.unzipToDir(zipStream,zipDestination);
-        String expectedText = "test";
-        
-        assertEquals(expPath, actualPath);
+        assertTrue(actualFile.exists());
+        assertTrue(actualFile.canRead());
+        assertTrue(actualFile.isFile());
+        String actualContents = new String(Files.readAllBytes(actualFile.toPath()));
+        String expectedContents = "test\n";
+        assertEquals(expectedContents, actualContents);
     }
           
     @Test(expected = ProcessException.class)

--- a/coastal-hazards-wps/src/test/java/gov/usgs/cida/coastalhazards/wps/FetchAndUnzipProcessTest.java
+++ b/coastal-hazards-wps/src/test/java/gov/usgs/cida/coastalhazards/wps/FetchAndUnzipProcessTest.java
@@ -170,10 +170,15 @@ public class FetchAndUnzipProcessTest {
      */
     @Test
     public void testUnzipSingleFileZipToDir() {       
-        assertZipFileUnzipsToPaths(
-            "gov/usgs/cida/coastalhazards/wps/oneFile.zip",
-            "test.txt"
-        );
+        String zipFileResourcePath = "gov/usgs/cida/coastalhazards/wps/oneFile.zip";
+
+        InputStream file = this.getClass().getClassLoader().getResourceAsStream(zipFileResourcePath);
+        ZipInputStream zipStream = new ZipInputStream(file);
+        File zipDestination = instance.getNewZipDestination();
+        File actualFile = instance.unzipToDir(zipStream,zipDestination);
+        String expectedText = "test";
+        
+        assertEquals(expPath, actualPath);
     }
           
     @Test(expected = ProcessException.class)


### PR DESCRIPTION
The changes here permit a user to create a raster layer in CCH via curl or via the web form. After uploading the user can visit the URL for the new CCH layer object . The layer object contains a 'serviceParameter' property. If you copy the value of this property, you can search for it in the GeoServer layer preview list, verify that it exists, and explore the dataset with OpenLayers. UPDATE: I have taken it to the next step -- I have created an item that relies on the raster layer and interacted with it in the portal web map ui.

To troubleshoot the raster layer import I had to perform a bunch of manual iterative tests. I couldn't find a way to quickly rename a TIFF and its zip file without re-zipping the whole huge TIFF each time (holy slow roller batman!) so I needed to find a way to upload the same file multiple times. I changed the TIFF filenames and the GeoServer layers (not to be confused with the CCH Layer objects) to use random ids.instead of the original filename so that I could upload the same zipped tiff multiple times. To simplify the implementation, the random ids for the TIFF filenames and the GeoServer layers are unrelated to the CCH layer ids (ex: ESF8pnhi). If desired, we could make them the same by supporting a file name parameter on the FetchAndUnzip WPS Process (1-pointer).

As I troubleshootered (or however that should be said;) ), I found some code problems, some configuration problems, and some data problems that were preventing the raster data from being exposed as layers in GeoServer. It is possible that we don't /need/ the random ids for the Geoserver layers+TIFF filenames in order for the system to function but at this point it may be annoying to back out those changes in tandem with the other necessary ones.

Code changes:
* UUID stuff, thus eliminating the need for raster files to have distinct names.
* Removed bug that caused files with multiple "."s in their name from being considered the same. Previously, 'ne_ae2020.carl.zip' and 'ne_ae2020.zip' were both being created as 'ne_ae2020' and thus failing.
* Converted a silent failure to a loud one when a raster store+layer could not be created on GeoServer. Even if we back out on UUIDs, this is especially important to keep.
* Added performance time logging for long-running operations to gain additional insight into bottlenecks and whether the apps were even still alive during testing ;)
* Parameterized a WMSService creation helper method so that custom workspaces could be specified. 

In the process of pursuing this last item, I looked through other code and noticed that the proxied workspace is often not parameterized ([example](https://github.com/USGS-CIDA/coastal-hazards/pull/1509/files#diff-a8c0cbcc67534bd2802a9b48ec2ba044R229)). Is workspace separation important enough to warrant parameterizing the workspace on several methods (or many? Sorry, I don't know how many yet), and updating usages accordingly?
@mhines-usgs, @smlarson-usgs: Do we really need to be putting raster files in their own dedicated workspace? In the short term it would likely be simpler to put both raster and vector in the same workspace. In the long term, I don't yet understand what we gain from a workspace separation. Could one of you please elaborate on the advantages of segregating the raster and vector data into different workspaces from a data management perspective?

Necessary local configuration changes:
* I ensured that the the context.xml's for both the geoserver instance and the portal instance had vars for the shared "fetch and unzip" token
* I ensured that the context.xml for the geoserver instance had a var for the "fetch and unzip" base dir.
* I ensured that the self-signed certs being presented by my local tomcat instances were both trusted in the system Java keystore. Previously only one of the certs was trusted.
* I synced my GeoServer admin password and the coastal-hazards.geoserver.password context.xml variable.
^ One or more of these may need to be performed on dev.

Data changes:
* I logged into GeoServer and created the "portal" workspace. I did this on dev too.