### PR TITLE
changing service_endpoint column from character varying(255) to text

### DIFF
--- a/coastal-hazards-liquibase/src/main/liquibase/100removeTextLimitService.xml
+++ b/coastal-hazards-liquibase/src/main/liquibase/100removeTextLimitService.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd" logicalFilePath="liquibaseChangeSet/100removeTextLimitService.xml">
+	<changeSet author="mhines" id="remove_text_limit_on_service_endpoint">
+		<modifyDataType tableName="service" columnName="service_endpoint" newDataType="text" />
+	</changeSet>
+</databaseChangeLog>

--- a/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/model/Service.java
+++ b/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/model/Service.java
@@ -56,13 +56,12 @@ public class Service implements Serializable {
 		this.id = id;
 	}
 
-	@Column(name = "service_endpoint", length = ENDPOINT_MAX_LENGTH)
+	@Column(name = "service_endpoint")
 	public String getEndpoint() {
 		return endpoint;
 	}
 
 	public void setEndpoint(String endpoint) {
-		StringPrecondition.checkStringArgument(endpoint, ENDPOINT_MAX_LENGTH);
 		this.endpoint = endpoint;
 	}
 


### PR DESCRIPTION
ran into an issue with changing the service_endpoint column contents to use https, because some URLs are actually 255 characters right now and can't fit in the s on https

