### PR TITLE
Enable caching in proxy in front of GeoServer 

### DIFF
--- a/coastal-hazards-portal/src/main/webapp/WEB-INF/web.xml
+++ b/coastal-hazards-portal/src/main/webapp/WEB-INF/web.xml
@@ -44,6 +44,10 @@
 			<param-value>coastal-hazards.portal.geoserver.cache.name</param-value>
 		</init-param>
 		<init-param>
+			<param-name>ignored-server-response-headers</param-name>
+			<param-value>expires,cache-control,age</param-value>
+		</init-param>
+		<init-param>
 			<param-name>max-megabytes-on-disk</param-name>
 			<param-value>8096</param-value>
 		</init-param>

--- a/pom.xml
+++ b/pom.xml
@@ -277,7 +277,7 @@
 			<dependency>
 				<artifactId>proxy-utils</artifactId>
 				<groupId>gov.usgs.cida</groupId>
-				<version>1.0.6</version>
+				<version>1.0.6.1</version>
 				<type>jar</type>
 				<exclusions>
 					<exclusion>


### PR DESCRIPTION
Enabling GeoServer tiles to be cached by specifying appropriate server response headers to ignore