### PR TITLE
Adding RCurl as a native system dependency

### DIFF
--- a/Docker/rserve/Dockerfile
+++ b/Docker/rserve/Dockerfile
@@ -40,6 +40,6 @@ RUN apt-get update && \
 	libcurl4-openssl-dev=7.38.0-4+deb8u4 \
 	libxml2-dev
  
-RUN install.r devtools && R -e 'library(devtools); install_github("USGS-R/hazarditems");'
+RUN install.r devtools && install.r RCurl && R -e 'library(devtools); install_github("USGS-R/hazarditems");'
 
 USER rserve

--- a/Docker/rserve/Dockerfile
+++ b/Docker/rserve/Dockerfile
@@ -40,6 +40,6 @@ RUN apt-get update && \
 	libcurl4-openssl-dev=7.38.0-4+deb8u4 \
 	libxml2-dev
  
-RUN install.r devtools && install.r RCurl && R -e 'library(devtools); install_github("USGS-R/hazarditems");'
+RUN install.r devtools RCurl && R -e 'library(devtools); install_github("USGS-R/hazarditems");'
 
 USER rserve


### PR DESCRIPTION
@jiwalker-usgs - you mentioned that RCurl was probably not an inherent need for the hazardItems package, rather that it was needed by the wrapper. Do you think this is a better place to capture the dependency than the imports in the hazardItems DESCRIPTION file?