### PR TITLE
New Item Order

### DIFF
--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/publish/UI.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/publish/UI.js
@@ -742,15 +742,33 @@ CCH.Objects.Publish.UI = function () {
 	me.updateSelectChange = function () {
 		if ($attributeSelectHelper.val() !== '') {
 			$attributeSelect.val($attributeSelectHelper.val());
+			me.unlockTitlesResourcesMetadata();
 		}
 	};
         
-        me.itemTypeCheck = function(){
-            [$titlesPanel.find('button, textarea'), $resourcesPanel.find('button'), $metaDataPanel.find('button, input')]
-                .each(function ($item) {
-                    $item.removeAttr(CCH.CONFIG.strings.disabled);
+	//Unlocks item type and features panel
+	me.unlockItemTypeFeatures = function () {
+	    [$typeSb, $featuresPanel.find('button, input')]
+		.each(function ($item) {
+		    $item.removeAttr(CCH.CONFIG.strings.disabled);
 		});
-        };
+	};
+
+	//Unlocks Titles, Resources, and Metadata Panels
+	me.unlockTitlesResourcesMetadata = function () {
+	    [$titlesPanel.find('button, textarea'), $resourcesPanel.find('button'), $metaDataPanel.find('button, input')]
+		.each(function ($item) {
+		    $item.removeAttr(CCH.CONFIG.strings.disabled);
+		});
+	};
+	
+	//Locks Titles, Resources, and Metadata Panels
+ 	me.lockTitlesResourcesMetadata = function () {
+	    [$titlesPanel.find('button, textarea'), $resourcesPanel.find('button'), $metaDataPanel.find('button, input')]
+                .each(function ($item) {
+                    $item.prop("disabled", true);
+                });
+	};
 
 	me.metadataPublishCallback = function (mdObject, status) {
 		if (status === 'success') {
@@ -1674,9 +1692,7 @@ CCH.Objects.Publish.UI = function () {
 
 	$popFromLayerButton.on(CCH.CONFIG.strings.click, function() {
 		me.loadLayerInfo($popFromLayerInput.val());
-                $typeSb.removeAttr(CCH.CONFIG.strings.disabled);
-                $attributeSelect.removeAttr(CCH.CONFIG.strings.disabled);
-                $featuresPanel.find('button, input').removeAttr(CCH.CONFIG.strings.disabled);
+                me.unlockItemTypeFeatures();
 	});
 
 	$sourceWfsCheckButton.on(CCH.CONFIG.strings.click, function () {
@@ -1989,6 +2005,7 @@ CCH.Objects.Publish.UI = function () {
 				}
 			});
 		}
+		$attributeSelect.removeAttr(CCH.CONFIG.strings.disabled);
 	});
 
 	$proxyWmsCheckButton.on(CCH.CONFIG.strings.click, function () {
@@ -2135,11 +2152,13 @@ CCH.Objects.Publish.UI = function () {
 	$vectorModalPopButton.on(CCH.CONFIG.strings.click, function(){
 		$popFromLayerInput.val($newVectorLayerId);
 		me.loadLayerInfo($popFromLayerInput.val());
+		me.unlockItemTypeFeatures();
 	});
 	
 	$rasterModalPopButton.on(CCH.CONFIG.strings.click, function(){
 		$popFromLayerInput.val($newRasterLayerId);
 		me.loadLayerInfo($popFromLayerInput.val());
+		me.unlockItemTypeFeatures();
 	});
 
 	me.clearForm();
@@ -2155,11 +2174,13 @@ CCH.Objects.Publish.UI = function () {
 	});
         
         //Checks to see if Attributes has a val and unlocks titles, Resources, and metdata for create new items
-        $attributeSelect.keyup(function(){
-            if($attributeSelect.val().length >= 3){
-                me.itemTypeCheck();
-            }
-        });
+	$attributeSelect.on('input', function () {
+	    if ($attributeSelect.val().length >= 3) {
+		me.unlockTitlesResourcesMetadata();
+	    } else {
+		me.lockTitlesResourcesMetadata();
+	    }
+	});
 
 	me.loadTemplates = function () {
 		["publication_row", "item_list"].each(function (templateName) {

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/publish/UI.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/publish/UI.js
@@ -92,6 +92,12 @@ CCH.Objects.Publish.UI = function () {
 		$isActiveStormRow = $form.find('#form-publish-info-item-active-storm'),
 		$isActiveStormChecbox = $form.find('#checkbox-isactive'),
 		$resourceSortableContainers = $('.resource-list-container-sortable'),
+                $servicePanel = $('#services-panel'),
+                $itemAttributePanel = $('#item-type-panel'),
+                $featuresPanel = $('#features-panel'),
+                $titlesPanel = $('#titles-panel'),
+                $resourcesPanel = $('#Resources-panel'),
+                $metaDataPanel = $('#metadata-panel'),
 		$newVectorLayerId = null,
 		$newRasterLayerId = null,
 		$editingEnabled = false;
@@ -172,24 +178,14 @@ CCH.Objects.Publish.UI = function () {
 		var gsBaseUrl = CCH.CONFIG.contextPath + CCH.CONFIG.data.sources[CCH.CONFIG.strings.cidaGeoserver].proxy + 'proxied/';
 		
 		$itemType.val('data');
+                
+                [$servicePanel.find('input, button'), $buttonSave, $buttonDelete]
+                        .each(function ($item) {
+                            $item.removeAttr(CCH.CONFIG.strings.disabled);
+			});
+                
+                
 		
-		[$titleFullTextArea, $titleMediumTextArea, $titleLegendTextArea, $descriptionFullTextArea,
-			$descriptionMediumTextArea, $descriptionTinyTextArea, $downloadLinkTextArea, $bboxNorth,
-			$typeSb, $attributeSelect, $attributeRetrieveDataButton, $attributeRetrieveTitlesButton,
-			$isFeaturedCB, $ribbonableCb, $popFromLayerInput, $popFromLayerButton,
-			$cswServiceInput, $cswServiceInputButton, $srcWfsServiceInput, $srcWfsServiceParamInput,
-			$srcWmsServiceInput, $srcWmsServiceParamInput, $proxyWfsServiceInput,
-			$proxyWfsServiceParamInput, $proxyWmsServiceInput, $getWfsAttributesButton,
-			$proxyWmsServiceParamInput,  $name, $wfsServerHelpButton,
-			$wfsSourceCopyButton, $sourceWfsCheckButton,
-			$sourceWmsCheckButton, $wmsServerHelpButton, $proxyWfsCheckButton,
-			$proxyWmsCheckButton, $buttonSave, $buttonDelete,
-			$publicationsPanel.find('#form-publish-info-item-panel-publications-button-add')]
-				.concat($keywordGroup.find('input'))
-				.concat($bboxes)
-				.each(function ($item) {
-					$item.removeAttr(CCH.CONFIG.strings.disabled);
-				});
 		$editingEnabled = true;
 		
 		if($newVectorLayerId !== null){
@@ -724,7 +720,7 @@ CCH.Objects.Publish.UI = function () {
 				.attr('value', '')
 				.html('');
 		$attributeSelectHelper.append(emptyOption);
-		
+                
 		if (featureTypes) {
 			featureTypes = featureTypes[0];
 			featureTypes.properties.each(function (ft) {
@@ -748,6 +744,13 @@ CCH.Objects.Publish.UI = function () {
 			$attributeSelect.val($attributeSelectHelper.val());
 		}
 	};
+        
+        me.itemTypeCheck = function(){
+            [$titlesPanel.find('button, textarea'), $resourcesPanel.find('button'), $metaDataPanel.find('button, input')]
+                .each(function ($item) {
+                    $item.removeAttr(CCH.CONFIG.strings.disabled);
+		});
+        };
 
 	me.metadataPublishCallback = function (mdObject, status) {
 		if (status === 'success') {
@@ -923,7 +926,7 @@ CCH.Objects.Publish.UI = function () {
 				
 				$attributeSelect.val(item.attr);
 				if (item.services.length > 0) {
-
+                                    
 					// Fill out services panel
 					if (services.csw) {
 						$cswServiceInput
@@ -1345,7 +1348,7 @@ CCH.Objects.Publish.UI = function () {
 
 	me.getDataForAttribute = function () {
 		var attribute = $attributeSelect.val();
-
+                
 		CCH.ows.requestSummaryByAttribute({
 			url: $('#form-publish-item-service-csw').val(),
 			attribute: attribute,
@@ -1359,7 +1362,7 @@ CCH.Objects.Publish.UI = function () {
 								me.createPublicationRow(publication.link, publication.title, type);
 							});
 						});
-
+                                                
 						response.keywords.split('|').each(function (keyword) {
 							me.addKeywordGroup(keyword);
 						});
@@ -1671,6 +1674,9 @@ CCH.Objects.Publish.UI = function () {
 
 	$popFromLayerButton.on(CCH.CONFIG.strings.click, function() {
 		me.loadLayerInfo($popFromLayerInput.val());
+                $typeSb.removeAttr(CCH.CONFIG.strings.disabled);
+                $attributeSelect.removeAttr(CCH.CONFIG.strings.disabled);
+                $featuresPanel.find('button, input').removeAttr(CCH.CONFIG.strings.disabled);
 	});
 
 	$sourceWfsCheckButton.on(CCH.CONFIG.strings.click, function () {
@@ -2145,7 +2151,15 @@ CCH.Objects.Publish.UI = function () {
 		} else {
 			$isActiveStormRow.addClass('hidden');
 		}
+                $itemAttributePanel.find('button').removeAttr(CCH.CONFIG.strings.disabled);
 	});
+        
+        //Checks to see if Attributes has a val and unlocks titles, Resources, and metdata for create new items
+        $attributeSelect.keyup(function(){
+            if($attributeSelect.val().length >= 3){
+                me.itemTypeCheck();
+            }
+        });
 
 	me.loadTemplates = function () {
 		["publication_row", "item_list"].each(function (templateName) {
@@ -2163,6 +2177,7 @@ CCH.Objects.Publish.UI = function () {
 			});
 		});
 	};
+        
 
 	me.initializeResourceSorting = function () {
 		$resourceSortableContainers.sortable({

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/publish/UI.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/publish/UI.js
@@ -748,7 +748,7 @@ CCH.Objects.Publish.UI = function () {
         
 	//Unlocks item type and features panel
 	me.unlockItemTypeFeatures = function () {
-	    [$typeSb, $featuresPanel.find('button, input')]
+	    [$typeSb, $attributeSelect,$featuresPanel.find('button, input')]
 		.each(function ($item) {
 		    $item.removeAttr(CCH.CONFIG.strings.disabled);
 		});
@@ -1052,6 +1052,8 @@ CCH.Objects.Publish.UI = function () {
 		} else {
 			CCH.LOG.warn('UI.js::addItemToForm: function was called with no item');
 		}
+		me.unlockItemTypeFeatures();
+		me.unlockTitlesResourcesMetadata();
 	};
 
 	me.wfsInfoUpdated = function () {
@@ -2005,7 +2007,6 @@ CCH.Objects.Publish.UI = function () {
 				}
 			});
 		}
-		$attributeSelect.removeAttr(CCH.CONFIG.strings.disabled);
 	});
 
 	$proxyWmsCheckButton.on(CCH.CONFIG.strings.click, function () {


### PR DESCRIPTION

How the new item page should work.
1.) Select New Item > Item : Only the Services Panel should be ungrayed.

2.) Once you fill in the Populate from Layer ex FauACWJh; and hit publish, the Item Type and Entire Feature panel unlocks. Should also unlock when you do create vector layer and hit Populate Services From Layer after you find the shapelayer you want to use.

3.) Selecting the Item type unlocks the Get Attributes Button.

4.) Clicking the Get Attributes Button unlocks both the Attributes input and the Type above (raster) or choose below (other) select.

5.) Either typing directly in the Attributes input (3 characters minimum) or selecting an option from the Type above (raster) or choose below (other) select, will unlock the rest of the options, which are Titles, Resources, and Metadata.

@zmoore-usgs Looks like I got it fixed