### PR TITLE
CCHS-336: Investigate upgrade pycsw version before spindling new stacks

### DIFF
--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/publish/UI.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/publish/UI.js
@@ -579,37 +579,39 @@ CCH.Objects.Publish.UI = function () {
 
 	me.updateFormWithNewCSWInfo = function (responseObject, textStatus) {
 		if (textStatus === 'success') {
-			
-			var cswNodes = responseObject.children,
-					tag;
-			cswNodes[0].children.each(function (node) {
-				tag = node.tag;
+		    //Bounding Box Information
+		    var bbox = responseObject["csw:GetRecordByIdResponse"].metadata.idinfo.spdom.bounding;
 
-				if (tag === 'idinfo') {
-					node.children.each(function (childNode) {
-						tag = childNode.tag;
-						switch (tag) {
-						case 'spdom':
-							if (childNode.children) {
-								childNode.children[0].children.each(function (spdom) {
-									var direction = spdom.tag.substring(0, spdom.tag.length - 2);
-									$('#form-publish-item-bbox-input-' + direction).val(spdom.text);
-								});
-							}
-							break;
-						case 'keywords':
-							childNode.children.each(function (kwNode) {
-								var keywords = kwNode.children;
-								keywords.splice(1).each(function (kwObject) {
-									var keyword = kwObject.text;
-									me.addKeywordGroup(keyword);
-								});
-							});
-							break;
-						}
-					});
-				}
-			});
+		    for(var dir in bbox){
+			if(bbox.hasOwnProperty(dir)){
+			    var direction = dir.substring(0, dir.length - 2);
+			    var text = bbox[dir]["#text"];
+			    
+			    if(text == null){
+				text = bbox[dir];
+			    }
+			    $('#form-publish-item-bbox-input-' + direction).val(text);
+			}
+		    }
+
+		    //Keywords
+		    var keywords = responseObject["csw:GetRecordByIdResponse"].metadata.idinfo.keywords;
+
+		    for(var category in keywords){
+			if(Array.isArray(keywords[category])){
+			    for(var sub in keywords[category]){
+				var listKey = category.trim() + "key"
+				keywords[category][sub][listKey].each(function(keyword) {
+				    me.addKeywordGroup(keyword);
+				})
+			    }
+			} else {
+			    var listKey = category.trim() + "key"
+			    keywords[category][listKey].each(function(keyword) {
+				me.addKeywordGroup(keyword);
+			    })
+			}
+		    }
 		}
 	};
 

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/publish/UI.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/publish/UI.js
@@ -598,22 +598,27 @@ CCH.Objects.Publish.UI = function () {
 		    var keywords = responseObject["csw:GetRecordByIdResponse"].metadata.idinfo.keywords;
 
 		    for(var category in keywords){
+			var listKey = category.trim() + "key"
 			if(Array.isArray(keywords[category])){
 			    for(var sub in keywords[category]){
-				var listKey = category.trim() + "key"
-				keywords[category][sub][listKey].each(function(keyword) {
-				    me.addKeywordGroup(keyword);
-				})
+				me.parseJsonKeywords(keywords[category][sub][listKey]);
 			    }
 			} else {
-			    var listKey = category.trim() + "key"
-			    keywords[category][listKey].each(function(keyword) {
-				me.addKeywordGroup(keyword);
-			    })
+			    me.parseJsonKeywords(keywords[category][listKey]);
 			}
 		    }
 		}
 	};
+	
+	me.parseJsonKeywords = function (keywords) {
+	    if(Array.isArray(keywords)){
+		keywords.each(function(keyword) {
+		    me.addKeywordGroup(keyword);
+		})
+	    } else {
+		me.addKeywordGroup(keywords);
+	    }
+	}
 
 	me.initNewItemForm = function () {
 		var $cswInput = $('#form-publish-item-service-csw'),

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/publish/UI.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/publish/UI.js
@@ -578,7 +578,41 @@ CCH.Objects.Publish.UI = function () {
 	};
 
 	me.updateFormWithNewCSWInfo = function (responseObject, textStatus) {
-		if (textStatus === 'success') {
+	    if (textStatus === 'success') {
+		if(responseObject.children != null){
+		    //PYCSW 1.x Support -- Remove After Server pycsw Upgrades Complete
+		    var cswNodes = responseObject.children;
+		    var tag;
+		    cswNodes[0].children.each(function (node) {
+			    tag = node.tag;
+
+			    if (tag === 'idinfo') {
+				    node.children.each(function (childNode) {
+					    tag = childNode.tag;
+					    switch (tag) {
+					    case 'spdom':
+						    if (childNode.children) {
+							    childNode.children[0].children.each(function (spdom) {
+								    var direction = spdom.tag.substring(0, spdom.tag.length - 2);
+								    $('#form-publish-item-bbox-input-' + direction).val(spdom.text);
+							    });
+						    }
+						    break;
+					    case 'keywords':
+						    childNode.children.each(function (kwNode) {
+							    var keywords = kwNode.children;
+							    keywords.splice(1).each(function (kwObject) {
+								    var keyword = kwObject.text;
+								    me.addKeywordGroup(keyword);
+							    });
+						    });
+						    break;
+					    }
+				    });
+			    }
+		    });
+		} else {
+		    //PYCSW 2.x Support
 		    //Bounding Box Information
 		    var bbox = responseObject["csw:GetRecordByIdResponse"].metadata.idinfo.spdom.bounding;
 
@@ -586,7 +620,7 @@ CCH.Objects.Publish.UI = function () {
 			if(bbox.hasOwnProperty(dir)){
 			    var direction = dir.substring(0, dir.length - 2);
 			    var text = bbox[dir]["#text"];
-			    
+
 			    if(text == null){
 				text = bbox[dir];
 			    }
@@ -608,6 +642,7 @@ CCH.Objects.Publish.UI = function () {
 			}
 		    }
 		}
+	    }
 	};
 	
 	me.parseJsonKeywords = function (keywords) {


### PR DESCRIPTION
Adds support for pycsw 2.x and keeps support for pycsw 1.x to smooth the transition. 1.x code should be removed once servers have been upgraded. 