### PR TITLE
CCHS-437: Updates to item delete logic and tree UI

### DIFF
--- a/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/jpa/DataDomainManager.java
+++ b/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/jpa/DataDomainManager.java
@@ -139,6 +139,19 @@ public class DataDomainManager implements AutoCloseable {
 	
 	return(delete(item.getId()));
     }
+
+    /**
+     * Delete the data domain associated with the given item ID
+     * @param itemId The item ID to delete the associated data domain for
+     * @return Boolean Representing whether or not the delete executed successfully.
+     */
+    public boolean deleteDomainForItemId(String itemId) {
+        if(itemId == null || itemId.length() == 0) {
+            throw new IllegalArgumentException("Item must be valid data item");
+        }
+
+        return delete(itemId);
+    }
     
     /**
      * Delete the data domain associated with the given item and then rebuild

--- a/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/jpa/JPAHelper.java
+++ b/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/jpa/JPAHelper.java
@@ -18,11 +18,11 @@ public class JPAHelper {
 	@PersistenceUnit
 	private static EntityManagerFactory emf = null;
 
-	public static EntityManagerFactory getEntityManagerFactory() {
+	public synchronized static EntityManagerFactory getEntityManagerFactory() {
 		return getEntityManagerFactory("coastalhazards");
 	}
 
-	public static EntityManagerFactory getEntityManagerFactory(String unit) {
+	public synchronized static EntityManagerFactory getEntityManagerFactory(String unit) {
 		if (emf == null) {
 			try {
 				emf = Persistence.createEntityManagerFactory(unit);
@@ -34,13 +34,13 @@ public class JPAHelper {
 		return emf;
 	}
 
-	public static void closeEntityManagerFactory() {
+	public synchronized static void closeEntityManagerFactory() {
 		if (emf != null && emf.isOpen()) {
 			emf.close();
 		}
 	}
 
-	public static void close(EntityManager em) {
+	public synchronized static void close(EntityManager em) {
 		if (em != null && em.isOpen()) {
 			em.close();
 		}

--- a/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/jpa/SessionManager.java
+++ b/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/jpa/SessionManager.java
@@ -105,7 +105,7 @@ public class SessionManager implements SessionIO, AutoCloseable {
 
     private List<String> getSessionIdsByItemId(String itemId) {
         Query sessions = em.createNativeQuery("SELECT session_id FROM session_item WHERE item_id = :itemId");
-		sessions.setParameter("itemId", itemId);
-		return (List<String>) sessions.getResultList();
+        sessions.setParameter("itemId", itemId);
+        return (List<String>) sessions.getResultList();
     }
 }

--- a/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/jpa/SessionManager.java
+++ b/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/jpa/SessionManager.java
@@ -1,38 +1,62 @@
 package gov.usgs.cida.coastalhazards.jpa;
 
 import gov.usgs.cida.coastalhazards.model.Session;
+import gov.usgs.cida.coastalhazards.model.SessionItem;
 import gov.usgs.cida.coastalhazards.session.io.SessionIO;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.List;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityTransaction;
+import javax.persistence.PersistenceException;
+import javax.persistence.Query;
+import org.apache.log4j.Logger;
 
 /**
  *
  * @author Jordan Walker <jiwalker@usgs.gov>
  */
-public class SessionManager implements SessionIO {
+public class SessionManager implements SessionIO, AutoCloseable {
+    
+    private static final Logger log = Logger.getLogger(SessionManager.class);
+    private EntityManager em;
+    
+    public SessionManager() {
+        em = JPAHelper.getEntityManagerFactory().createEntityManager();
+    }
+
+    @Override
+	public void close() {
+		JPAHelper.close(em);
+	}
 
     @Override
     public String load(String sessionID) {
         String jsonSession = null;
-        EntityManager em = JPAHelper.getEntityManagerFactory().createEntityManager();
         try {
             Session session = em.find(Session.class, sessionID);
 
-            
             if (null != session) {
                 jsonSession = session.toJSON();
             }
-        } finally {
-            JPAHelper.close(em);
-        }
+        } catch (PersistenceException ex) {
+			log.error("Unable to load session", ex);
+		}
         return jsonSession;
+    }
+
+    private Session loadSession(String sessionID) {
+        try {
+            return em.find(Session.class, sessionID);
+        } catch (PersistenceException ex) {
+			log.error("Unable to load session", ex);
+        }
+        return null;
     }
 
     @Override
     public synchronized String save(String session) {
         String id = "ERR";
-        EntityManager em = JPAHelper.getEntityManagerFactory().createEntityManager();
         EntityTransaction transaction = em.getTransaction();
         try {
             transaction.begin();
@@ -44,10 +68,44 @@ public class SessionManager implements SessionIO {
             if (transaction.isActive()) {
                 transaction.rollback();
             }
-        } finally {
-            JPAHelper.close(em);
         }
         return id;
     }
 
+    public synchronized boolean removeItemFromSessions(String itemId) {
+        EntityTransaction transaction = em.getTransaction();
+
+        for(String sessionId : getSessionIdsByItemId(itemId)) {
+            try {
+                Session sessionObj = loadSession(sessionId);
+                List<SessionItem> newItems = new ArrayList<>(sessionObj.getItems());
+
+                for(SessionItem item : sessionObj.getItems()) {
+                    if(item.getItemId().equals(itemId)){
+                        newItems.remove(item);
+                    }
+                }
+
+                transaction.begin();
+                em.remove(sessionObj);
+                sessionObj.setItems(newItems);
+                em.persist(sessionObj);
+                transaction.commit();
+            } catch (Exception ex) {
+                if (transaction.isActive()) {
+                    transaction.rollback();
+                }
+                log.error("An error occurred while modifying the session. Error: " + ex.getMessage());
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private List<String> getSessionIdsByItemId(String itemId) {
+        Query sessions = em.createNativeQuery("SELECT session_id FROM session_item WHERE item_id = :itemId");
+		sessions.setParameter("itemId", itemId);
+		return (List<String>) sessions.getResultList();
+    }
 }

--- a/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/rest/data/ItemResource.java
+++ b/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/rest/data/ItemResource.java
@@ -221,7 +221,7 @@ public class ItemResource {
 		
 		try (ItemManager itemManager = new ItemManager()) {
 			if(itemManager.isOrphan(id)){
-				if (itemManager.delete(id, deleteChildren, true)) {
+				if (itemManager.delete(id, deleteChildren)) {
 					response = Response.ok().build();
 				} else {
 					throw new Error();

--- a/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/rest/data/TreeResource.java
+++ b/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/rest/data/TreeResource.java
@@ -205,6 +205,7 @@ public class TreeResource {
 				if(totalItemCount == 0){
 					log.error("Incoming content had no items.");
 					response = Response.status(Response.Status.BAD_REQUEST).build();
+					return response;
 				}
 
 				response = Response.ok().build();

--- a/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/rest/data/TreeResource.java
+++ b/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/rest/data/TreeResource.java
@@ -153,9 +153,14 @@ public class TreeResource {
 		if (StringUtils.isNotBlank(content)) {
 			try {
 				JsonObject jsonObj = (JsonObject) new JsonParser().parse(content);
-				
-				Set<Entry<String, JsonElement>> entrySet = jsonObj.entrySet();
+				int totalItemCount = 0;
+
+				// Update Items
+				JsonObject updateItems = jsonObj.getAsJsonObject("data");
+				Set<Entry<String, JsonElement>> entrySet = updateItems.entrySet();
 				int itemCount = entrySet.size();
+				totalItemCount += itemCount;
+
 				if (itemCount > 0) {
 					// Create the map that the updating function expects 
 					Map<String, JsonObject> itemMap = new HashMap<>();
@@ -164,16 +169,45 @@ public class TreeResource {
 					}
 
 					// Now that I have the map, update the items
-					if (updateItemChildren(itemMap)) {
-						response = Response.ok().build();
-					} else {
+					if (!updateItemChildren(itemMap)) {
 						response = Response.serverError().build();
+						log.error("An error occurred while updating items! Skipping deletes.");
+						return response;
 					}
 				} else {
-					log.error("Incoming content had no items");
+					log.info("Incoming content had no item updates");
+				}
+
+				// Delete items that aren't deleting their orphaned children
+				JsonArray  deleteNoChildren = jsonObj.getAsJsonArray("deleteNoChildren");
+				itemCount = deleteNoChildren.size();
+				totalItemCount += itemCount;
+
+				if(!deleteItems(deleteNoChildren, false)){
+					response = Response.serverError().build();
+					log.error("An error occurred while deleteing items and orphaning children! Skipping deletes with children.");
+					return response;
+				}
+				
+				
+				// Then delete Items that are deleting their orphaned children
+				JsonArray  deleteWithChildren = jsonObj.getAsJsonArray("deleteWithChildren");
+				itemCount = deleteWithChildren.size();
+				totalItemCount += itemCount;
+
+				if(!deleteItems(deleteWithChildren, true)){
+					response = Response.serverError().build();
+					log.error("An error occurred while deleteing items and children!");
+					return response;
+				}
+
+				//If there was no data recieved then return as a bad request
+				if(totalItemCount == 0){
+					log.error("Incoming content had no items.");
 					response = Response.status(Response.Status.BAD_REQUEST).build();
 				}
 
+				response = Response.ok().build();
 			} catch (JsonSyntaxException ex) {
 				log.error("Could not parse incoming content: {}", content, ex);
 				response = Response.status(Response.Status.BAD_REQUEST).build();
@@ -270,4 +304,33 @@ public class TreeResource {
 		return updated;
 	}
 
+	private boolean deleteItems(JsonArray toDelete, boolean deleteChildren) {
+		boolean returnStatus = true;
+
+		for(JsonElement item : toDelete){
+			String itemId = item.getAsString();
+
+			try (ItemManager itemManager = new ItemManager()) {
+				if(itemManager.isOrphan(itemId)){
+					if (!itemManager.delete(itemId, deleteChildren)) {
+						log.error("Failed to delete some items marked for delete [item: " + itemId + "] [delete children: " + (deleteChildren ? "yes" : "no") + "].");
+						returnStatus = false;
+					} else {
+						log.info("Successfully deleted item " + itemId + " [delete children: " + (deleteChildren ? "yes" : "no") + "].");
+					}
+				} else {
+					log.info("Item " + itemId + " skipped because it is not an orphan.");
+				}
+			} catch(Exception e){
+				log.error("Failed to delete some items marked for delete [delete children: " + (deleteChildren ? "yes" : "no") + "]. Error: " + e.getMessage());
+				returnStatus = false;
+			}
+
+			if(!returnStatus){
+				break;
+			}
+		}
+
+		return returnStatus;
+	}
 }

--- a/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/publish/tree/index.jsp
+++ b/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/publish/tree/index.jsp
@@ -64,20 +64,18 @@
 				<div class="col-md-12">
 					<p class="lead">Instructions</p>
 					<p class="text-muted">
-						"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed 
-						do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
-						Ut enim ad minim veniam, quis nostrud exercitation ullamco 
-						laboris nisi ut aliquip ex ea commodo consequat. Duis aute 
-						irure dolor in reprehenderit in voluptate velit esse cillum 
-						dolore eu fugiat nulla pariatur. Excepteur sint occaecat 
-						cupidatat non proident, sunt in culpa qui officia deserunt 
-						mollit anim id est laborum."
+						"Click and drag items to re-order them within the tree. Only items nested 
+						underneath 'Uber' will be displayed on the portal UI. Items nested under 
+						'Orphans' will still exist in the portal database but will not be shown
+						through the UI. Right click an item for additional available actions. Changes
+						made to the tree will not be applied unless you click the 'Save' button. If
+						the page is refreshed without 'Save' being clicked changes made will be lost."
 					</p>
 				</div>
 			</div>
 			<div class="row">
 				<div class="col-md-6">
-					<i class="fa fa-search"></i><input type="text" id="search-input" />			
+					<i class="fa fa-search"></i><input type="text" id="search-input" /><button id="clear-search" class="btn">Clear Search</button>		
 				</div>
 
 				<div id="save-button-container" class="col-md-6">

--- a/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/publish/tree/index.jsp
+++ b/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/publish/tree/index.jsp
@@ -76,7 +76,7 @@
 			<div class="row">
 				<div class="col-md-6">
 					<i class="fa fa-search"></i><input type="text" id="search-input" /><button id="search-button" class="btn btn-success">Search</button>
-					&nbsp;&nbsp;&nbsp;<button id="clear-search" class="btn btn-warning">Clear Search</button>		
+					&nbsp;&nbsp;<button id="clear-search" class="btn btn-warning">Clear Search</button>		
 				</div>
 
 				<div id="save-button-container" class="col-md-6">

--- a/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/publish/tree/index.jsp
+++ b/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/publish/tree/index.jsp
@@ -75,7 +75,8 @@
 			</div>
 			<div class="row">
 				<div class="col-md-6">
-					<i class="fa fa-search"></i><input type="text" id="search-input" /><button id="clear-search" class="btn">Clear Search</button>		
+					<i class="fa fa-search"></i><input type="text" id="search-input" /><button id="search-button" class="btn btn-success">Search</button>
+					&nbsp;&nbsp;&nbsp;<button id="clear-search" class="btn btn-warning">Clear Search</button>		
 				</div>
 
 				<div id="save-button-container" class="col-md-6">

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/publish/UI.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/publish/UI.js
@@ -1590,10 +1590,6 @@ CCH.Objects.Publish.UI = function () {
 					url: CCH.CONFIG.contextPath + '/data/item/' + id + "?deleteChildren=" + $("#deleteChildren").is(':checked').toString(),
 					method: 'DELETE',
 					success: function () {
-						$.ajax({
-							url: CCH.CONFIG.contextPath + '/data/alias/item/' + id,
-							method: 'DELETE'
-						});
 						window.location = CCH.CONFIG.contextPath + '/publish/item/';
 					},
 					error: function (jqXHR, err, errTxt) {

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/publish/tree/OnReady.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/publish/tree/OnReady.js
@@ -22,6 +22,7 @@ $(document).ready(function () {
 		'$treeContainer' : $('#tree-container'),
 		'$saveButton' : $('#save-button'),
 		'$clearSearchButton' : $('#clear-search'),
+		'$searchButton' : $('#search-button'),
 		'$searchInput' : $('#search-input')
 	});
 });

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/publish/tree/OnReady.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/publish/tree/OnReady.js
@@ -21,6 +21,7 @@ $(document).ready(function () {
 		'$diagramContainer' : $('#app-container'),
 		'$treeContainer' : $('#tree-container'),
 		'$saveButton' : $('#save-button'),
+		'$clearSearchButton' : $('#clear-search'),
 		'$searchInput' : $('#search-input')
 	});
 });

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/publish/tree/OnReady.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/publish/tree/OnReady.js
@@ -21,8 +21,8 @@ $(document).ready(function () {
 		'$diagramContainer' : $('#app-container'),
 		'$treeContainer' : $('#tree-container'),
 		'$saveButton' : $('#save-button'),
-		'$clearSearchButton' : $('#clear-search'),
 		'$searchButton' : $('#search-button'),
+		'$clearSearchButton' : $('#clear-search'),
 		'$searchInput' : $('#search-input')
 	});
 });

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/publish/tree/UI.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/publish/tree/UI.js
@@ -695,7 +695,7 @@ CCH.Objects.Publish.Tree.UI = function (args) {
 				var $nodeElement = $('#' + node.li_attr.id + '_anchor');
 				$nodeElement.removeClass(searchClass);
 			}
-			me.$searchInput.val = "";
+			me.$searchInput.val("");
 		} else {
 			console.log("Error - Could not get root item from tree.");
 			console.log(tree);

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/publish/tree/UI.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/publish/tree/UI.js
@@ -14,6 +14,7 @@ CCH.Objects.Publish.Tree.UI = function (args) {
 	me.deletedItems = {};
 	me.highlightedNodes = [];
 	me.autoSearch = "";
+	me.rootItems = ["#", "root", "uber", "orphans"];
 
 
 	// The individual tree node.
@@ -99,115 +100,8 @@ CCH.Objects.Publish.Tree.UI = function (args) {
 				'check_callback': true
 			},
 			'contextmenu': {
-				'items': {
-					'edit': {
-						'label': 'Edit',
-						'icon': 'fa fa-pencil-square-o',
-						'action': function () {
-							var tree = CCH.ui.getTree(),
-									selectedId = tree.get_selected()[0],
-									originalId = tree.get_node(selectedId).state['original-id'];
-
-							window.location = CCH.config.baseUrl + "/publish/item/" + originalId;
-						}
-					},
-					'delete': {
-						'label': 'Orphan',
-						'icon': 'fa fa-user-o',
-						'action': function () {
-							var tree = CCH.ui.getTree(),
-									selectedIds = tree.get_selected();
-
-								for(var i = 0; i < selectedIds.length; i++){
-									var selectedId = selectedIds[i],
-										parentId = tree.get_parent(selectedId);
-									
-									if (selectedId.toLowerCase() !== 'uber') {
-										tree.move_node(selectedId, 'orphans');
-										me.itemUpdated(parentId);
-									}
-								}
-						}
-					},
-					'delete-all': {
-						'label': 'Remove Copies',
-						'icon': 'fa fa-eraser',
-						'action': function () {
-							var tree = CCH.ui.getTree(),
-									selectedIds = tree.get_selected();
-							
-							for(var i = 0; i < selectedIds.length; i++){
-								var selectedId = selectedIds[i],
-									selectedNode = tree.get_node(selectedId),
-									originalId = selectedNode.state['original-id'],
-									allNodes = me.findNodesByItemId(originalId);
-
-								for(var j = 0; j < allNodes.length; j++){
-									var nodeId = allNodes[j].id;
-
-									if(!selectedIds.includes(nodeId)){
-										var parentId = tree.get_parent(nodeId);
-										tree.delete_node(nodeId);
-										me.itemUpdated(parentId);
-									}
-								}
-							}
-						}
-					},
-					'remove-delete-children': {
-						'label': 'Mark for Delete (Delete Orphaned Children)',
-						'icon': 'fa fa-trash',
-						'action': function() {
-							me.deleteContextAction(true);
-						}
-					},
-					'remove-orphan-children': {
-						'label': 'Mark for Delete (Orphan Children)',
-						'icon': 'fa fa-trash',
-						'action': function() {
-							me.deleteContextAction(false);
-						}
-					},
-					'highlight': {
-						'label': 'Highlight Copies',
-						'icon': 'fa fa-circle',
-						'action': function () {
-							var tree = CCH.ui.getTree(),
-								selectedId = tree.get_selected()[0],
-								node = tree.get_node(selectedId),
-								originalId = node.state['original-id'];
-								
-							if(me.highlightedNodes.includes(node)){
-								me.toggleHighlightedNodes([]);
-							} else {
-								me.toggleHighlightedNodes(me.findNodesByItemId(originalId));
-							}		
-						}
-					},
-					'displayed': {
-						'label': 'Toggle Visibility',
-						'icon': 'fa fa-eye',
-						'action': function () {
-							var tree = CCH.ui.getTree(),
-									selectedId = tree.get_selected()[0],
-									node = CCH.ui.getTree().get_node(selectedId),
-									parent = tree.get_node(node.parent),
-									originalId = node.state['original-id'];
-
-							var displayed = node.state.displayed;
-							if (displayed) {
-								node.state.displayed = false;
-								$('#' + selectedId + '_anchor');
-								parent.state.displayedChildren.remove(originalId);
-							} else {
-								node.state.displayed = true;
-								parent.state.displayedChildren = parent.state.displayedChildren.union(originalId);
-							}
-							tree.save_state();
-							me.itemUpdated(parent.id);
-							me.updateItemsLook();
-						}
-					}
+				'items': function ($node) {
+					return me.createNodeContextMenu($node);
 				}
 			},
 			'types': {
@@ -232,10 +126,343 @@ CCH.Objects.Publish.Tree.UI = function (args) {
 			'plugins': ['contextmenu', 'dnd', 'types', 'state', 'search']
 		});
 
+		me.createNodeContextMenu = function(node){
+			var items = {
+					'edit': {},
+					'highlight': {},
+					'orphan': {},
+					'removeCopies': {},
+					'deleteWithChildren': {},
+					'deleteNoChildren': {},
+					'visibility': {}
+				},
+				tree = CCH.ui.getTree(),
+				selectedIds = tree.get_selected();
+
+			//Make sure we're creating the context menu for a valid CCH Item Node
+			if (node.parents.length < 3 || selectedIds.includes('orphans') || selectedIds.includes('root') || selectedIds.includes('uber') || selectedIds.includes('#')) {
+				return items;
+			} else {
+				//Make sure the node we clicked is selected, otherwise deslsect what's selected and select it
+				if (!selectedIds.includes(node.id)){
+					tree.deselect_all();
+					tree.select_node(node.id);
+					selectedIds = tree.get_selected();
+				}
+
+				//Determine Selected Node Group Common Properties
+				var showHighlight = selectedIds.length === 1,
+					showEdit = selectedIds.length === 1,
+					showVisibility = true,
+					showOrphan = true,
+					showDelete = true;
+
+				for (var i = 0; i < selectedIds.length; i++){
+					var selectedId = selectedIds[i],
+						checkNode = tree.get_node(selectedIds[i]);
+					
+					//Show orphan row if all selected nodes can show it
+					if (showOrphan) {
+						showOrphan = showOrphan && me.canShowOrphanRow(checkNode);
+					}
+					
+					//Show delete row if all selected nodes can show it and all have same delete state
+					if (showDelete) {
+						showDelete = me.canShowDeleteRows(checkNode) && 
+									checkNode.state['to-delete'] === node.state['to-delete'] &&
+									(node.state['to-delete'] ? checkNode.state['delete-children'] === node.state['delete-children'] : true);
+					}
+
+					//Show visibility row if all selected nodes can show it and all have same visibility
+					if (showVisibility) {
+						showVisibility = me.canShowVisibilityRow(checkNode) && 
+										checkNode.state['visibility'] === checkNode.state['visibility'];
+					}
+
+					//Stop looping if we can't show any context entries
+					if (!(showOrphan || showDelete || showVisibility)){
+						break;
+					}
+				}
+
+				//Create Rows
+				if (showEdit) {
+					items.edit = me.createEditMenuRow(node);
+				} else {
+					delete items.edit;
+				}
+
+				if (showVisibility) {
+					items.visibility = me.createVisibilityMenuRow(node);
+				} else {
+					delete items.visibility;
+				}
+
+				if (showHighlight) {
+					items.highlight = me.createHighlightMenuRow(node);
+				} else {
+					delete items.highlight;
+				}
+
+				if (showOrphan) {
+					items.orphan = me.createOrphanMenuRow(node);
+				} else {
+					delete items.orphan;
+				}
+
+				//Always show the "remove all copies" row
+				items.removeCopies = me.createRemoveCopiesMenuRow(node);
+
+				if (showDelete) {
+					items.deleteWithChildren = me.createDeleteWithChildrenMenuRow(node);
+					items.deleteNoChildren = me.createDeleteNoChildrenMenuRow(node);
+
+					//If we are marked to delete show only the toggled row
+					if (items.deleteWithChildren === null) {
+						delete items.deleteWithChildren;
+					}
+					else if (items.deleteNoChildren === null) {
+						delete items.deleteNoChildren;
+					}
+				} else {
+					delete items.deleteWithChildren;
+					delete items.deleteNoChildren;
+				}
+				
+				return items;
+			}
+		}
+
+		me.createContextRow = function(label, icon, action){
+			var row = {
+				'label': label,
+				'icon': 'fa ' + icon,
+				'action': action
+			}
+			return row;
+		}
+
+		me.createEditMenuRow = function(node) {
+			var label = "Edit",
+				icon = "fa-pencil";
+
+			return me.createContextRow(label, icon, me.editContextAction);
+		}
+
+		me.createOrphanMenuRow = function(node) {
+			var label = "Orphan",
+				icon = "fa-user-o";
+
+			return me.createContextRow(label, icon, me.orphanContextAction);
+		}
+
+		me.createRemoveCopiesMenuRow = function(node) {
+			var label = "Remove Copies",
+				icon = "fa-eraser";
+
+			return me.createContextRow(label, icon, me.removeCopiesContextAction);
+		}
+
+		me.createDeleteWithChildrenMenuRow = function(node) {
+			var labelToDo = "Mark for Delete (Delete Orphaned Children)",
+				labelToUndo = "Un-" + labelToDo,
+				iconToDo = "fa-trash",
+				iconToUndo = "fa-trash-o";
+
+			if (node.state['to-delete']) {
+				if (node.state['delete-children']) {
+					return me.createContextRow(labelToUndo, iconToUndo, function(){me.deleteContextAction(true)});
+				} else {
+					return null;
+				}
+			} else {
+				return me.createContextRow(labelToDo, iconToDo, function(){me.deleteContextAction(true)});
+			}
+		}
+
+		me.createDeleteNoChildrenMenuRow = function(node) {
+			var labelToDo = "Mark for Delete (Orphan Children)",
+				labelToUndo = "Un-" + labelToDo,
+				iconToDo = "fa-trash",
+				iconToUndo = "fa-trash-o";
+
+			if (node.state['to-delete']) {
+				if (!node.state['delete-children']) {
+					return me.createContextRow(labelToUndo, iconToUndo, function(){me.deleteContextAction(false)});
+				} else {
+					return null;
+				}
+			} else {
+				return me.createContextRow(labelToDo, iconToDo, function(){me.deleteContextAction(false)});
+			}
+		}
+
+		me.createHighlightMenuRow = function(node) {
+			var labelToDo = "Highlight Copies",
+				labelToUndo = "Un-" + labelToDo,
+				iconToDo = "fa-circle",
+				iconToUndo = "fa-circle-o";
+
+			if (me.highlightedNodes.includes(node)){
+				return me.createContextRow(labelToUndo, iconToUndo, me.highlightContextAction);
+			} else {
+				return me.createContextRow(labelToDo, iconToDo, me.highlightContextAction);
+			}
+		}
+
+		me.createVisibilityMenuRow = function(node) {
+			var label = "Toggle Visibility",
+				iconToDo = "fa-eye",
+				iconToUndo = "fa-eye-slash";
+
+			if (node.state['displayed']){
+				return me.createContextRow(label, iconToUndo, me.visibilityContextAction);
+			} else {
+				return me.createContextRow(label, iconToDo, me.visibilityContextAction);
+			}
+		}
+
+		me.canShowVisibilityRow = function(node){
+			if (node.parent && !me.rootItems.includes(node.parent) && node.parents.includes('uber')) {
+				return true;
+			}
+			return false;
+		}
+	
+		me.canShowOrphanRow = function(node){
+			if (node.parents.includes('uber') || node.parents.length > 3) {
+				return true;
+			}
+			return false;
+		}
+	
+		me.canShowDeleteRows = function(node){
+			if (node.parents.includes('orphans') && node.parents.length == 3) {
+				return true;
+			}
+			return false;
+		}	
+
+		me.editContextAction = function () {
+			var tree = CCH.ui.getTree(),
+				selectedId = tree.get_selected()[0],
+				originalId = tree.get_node(selectedId).state['original-id'];
+
+			window.location = CCH.config.baseUrl + "/publish/item/" + originalId;
+		}
+
+		me.orphanContextAction = function() {
+			var tree = CCH.ui.getTree(),
+				selectedIds = tree.get_selected();
+
+			for (var i = 0; i < selectedIds.length; i++){
+				var selectedId = selectedIds[i],
+					parentId = tree.get_parent(selectedId);
+				
+				if (!me.rootItems.includes(selectedId.toLowerCase())) {
+					tree.move_node(selectedId, 'orphans');
+					me.itemUpdated(parentId);
+				}
+			}
+		}
+
+		me.removeCopiesContextAction = function() {
+			var tree = CCH.ui.getTree(),
+			selectedIds = tree.get_selected();
+	
+			for (var i = 0; i < selectedIds.length; i++){
+				var selectedId = selectedIds[i],
+					selectedNode = tree.get_node(selectedId),
+					originalId = selectedNode.state['original-id'],
+					allNodes = me.findNodesByItemId(originalId);
+
+				for (var j = 0; j < allNodes.length; j++){
+					var nodeId = allNodes[j].id;
+
+					if (!selectedIds.includes(nodeId)){
+						var parentId = tree.get_parent(nodeId);
+						tree.delete_node(nodeId);
+						me.itemUpdated(parentId);
+					}
+				}
+			}
+		}
+
+		me.deleteContextAction = function(deleteChildren){
+			var tree = CCH.ui.getTree(),
+				selectedIds = tree.get_selected();
+			var processedItems = [];
+	
+			for (var i = 0; i < selectedIds.length; i++){
+				var selectedId = selectedIds[i],
+					node = tree.get_node(selectedId),
+					originalId = node.state['original-id'];
+				
+				if (!processedItems.includes(originalId)){
+					//Add this item to the processed items list so we don't process any copies of node which would undo these actions
+					processedItems.push(originalId);
+	
+					if (selectedId.toLowerCase() !== 'uber' && selectedId.toLowerCase() !== 'orphans') {
+						if (me.isNodeItemOrphaned(selectedId)) {
+							var itemNodes = me.findNodesByItemId(originalId);
+	
+							//Mark item and all duplicates for Delete
+							for (var j = 0; j < itemNodes.length; j++){
+								var curNode = itemNodes[j];
+								curNode.state['to-delete'] = !curNode.state['to-delete'];
+								curNode.state['delete-children'] = deleteChildren;
+							}
+							
+							me.markDeleteNodes();
+						} else {
+							//Display message that it's not an orphan
+							alert("There are copies of a selected item in the tree which are not orphans. In order to delete the selected items all copies must also be orphaned.");
+						}
+					}
+				}
+			}
+		}
+
+		me.highlightContextAction = function() {
+			var tree = CCH.ui.getTree(),
+				selectedId = tree.get_selected()[0],
+				node = tree.get_node(selectedId),
+				originalId = node.state['original-id'];
+				
+			if (me.highlightedNodes.includes(node)){
+				me.toggleHighlightedNodes([]);
+			} else {
+				me.toggleHighlightedNodes(me.findNodesByItemId(originalId));
+			}
+		}
+
+		me.visibilityContextAction = function() {
+			var tree = CCH.ui.getTree(),
+				selectedId = tree.get_selected()[0],
+				node = CCH.ui.getTree().get_node(selectedId),
+				parent = tree.get_node(node.parent),
+				originalId = node.state['original-id'];
+
+			var displayed = node.state.displayed;
+
+			if (displayed) {
+				node.state.displayed = false;
+				$('#' + selectedId + '_anchor');
+				parent.state.displayedChildren.remove(originalId);
+			} else {
+				node.state.displayed = true;
+				parent.state.displayedChildren = parent.state.displayedChildren.union(originalId);
+			}
+
+			tree.save_state();
+			me.itemUpdated(parent.id);
+			me.updateItemsLook();
+		}
+
 		me.$treeContainer.bind({
 			'select_node.jstree': function(evt, selectEvt) {
 				var selectedId = selectEvt.node.id;
-				if(selectedId === 'uber' || selectedId === 'orphans' || selectedId === 'root' || selectedId === '#'){
+				if (me.rootItems.includes(selectedId.toLowerCase())){
 					CCH.ui.getTree().deselect_node(selectedId);
 				}
 			},
@@ -251,9 +478,9 @@ CCH.Objects.Publish.Tree.UI = function (args) {
 				} else {
 					//Coalesce Duplicates
 					var newParentNode =  tree.get_node(newParent);
-					for(var i = 0; i < newParentNode.children.length; i++){
+					for (var i = 0; i < newParentNode.children.length; i++){
 						var childNode = tree.get_node(newParentNode.children[i]);
-						if(childNode.state['original-id'] === moveEvt.node.state['original-id'] && childNode.id !== moveEvt.node.id){
+						if (childNode.state['original-id'] === moveEvt.node.state['original-id'] && childNode.id !== moveEvt.node.id){
 							tree.delete_node(moveEvt.node);
 						}
 					}
@@ -274,12 +501,12 @@ CCH.Objects.Publish.Tree.UI = function (args) {
 				// I don't want to allow users to copy to the root node, to orphans,
 				// or to any item under orphans, or to a parent that already contains a copy of this item
 				var copyCount = 0;
-				for(var i = 0; i < newParentNode.children.length; i++){
+				for (var i = 0; i < newParentNode.children.length; i++){
 					var childNode = tree.get_node(newParentNode.children[i]);
-					if(childNode.state['original-id'] === copyEvt.node.state['original-id']){
+					if (childNode.state['original-id'] === copyEvt.node.state['original-id']){
 						copyCount++;
 						
-						if(copyCount > 1){
+						if (copyCount > 1){
 							break;
 						}
 					}
@@ -297,7 +524,7 @@ CCH.Objects.Publish.Tree.UI = function (args) {
 					tree.set_id(copyEvt.node, CCH.Util.Util.generateUUID());
 					copyEvt.node.a_attr.id = copyEvt.node.id + "_anchor";
 
-					if(doHighlight) {
+					if (doHighlight) {
 						me.highlightedNodes.push(copyEvt.node);
 					}
 
@@ -307,240 +534,11 @@ CCH.Objects.Publish.Tree.UI = function (args) {
 				}
 				me.updateItemsLook();
 			},
-			'show_contextmenu.jstree': function (evt, obj) {
-				var clickedNode = obj.node,
-					tree = CCH.ui.getTree(),
-					selectedIds = tree.get_selected();
-
-				if(!selectedIds.includes(clickedNode.id)){
-					tree.deselect_all();
-					tree.select_node(clickedNode.id);
-					selectedIds = tree.get_selected();
-				}
-
-				//Don't show the context menu at all if  a non-CCH Item node is selected
-				if(clickedNode.parents.length < 3 || selectedIds.includes('orphans') || selectedIds.includes('root') || selectedIds.includes('uber') || selectedIds.includes('#')) {
-					$('.jstree-contextmenu').addClass('hidden');
-				} else {
-					//Show Context Menu
-					$('.jstree-contextmenu').removeClass('hidden');
-
-					//Determine Selected Node Group Common Properties
-					var showHighlight = selectedIds.length === 1,
-						showEdit = selectedIds.length === 1,
-						showVisibility = true,
-						showOrphan = true,
-						showDelete = true;
-
-					for(var i = 0; i < selectedIds.length; i++){
-						var selectedId = selectedIds[i],
-							node = tree.get_node(selectedId);
-						
-						//Show orphan row if all selected nodes can show it
-						if(showOrphan) {
-							showOrphan = showOrphan && me.canShowOrphanRow(node);
-						}
-						
-						//Show delete row if all selected nodes can show it and all have same delete state
-						if(showDelete) {
-							showDelete = me.canShowDeleteRows(node) && node.state['to-delete'] === clickedNode.state['to-delete'] && node.state['delete-children'] === clickedNode.state['delete-children'];
-						}
-
-						//Show visibility row if all selected nodes can show it and all have same visibility
-						if(showVisibility) {
-							showVisibility = me.canShowVisibilityRow(node) && node.state['visibility'] === clickedNode.state['visibility'];
-						}
-
-						//Stop looping if we can't show any context entries
-						if(!(showOrphan || showDelete || showVisibility)){
-							break;
-						}
-					}
-
-					//Toggle Edit Context Entry
-					me.toggleEditContext(showEdit);
-
-					//Toggle Orphan Context Entries
-					me.toggleOrphanContext(showOrphan);
- 
-					//Toggle Delete Context Entries
-					me.toggleDeleteContext(showDelete, clickedNode.state['to-delete'], clickedNode.state['delete-children']);
-
-					//Toggle Highlight Context Entry Icon
-					me.toggleHighlightContext(showHighlight, me.highlightedNodes.includes(clickedNode));
-
-					//Toggle Visibility Context Entry and Icon
-					me.toggleVisibilityContext(showVisibility, clickedNode.state['visibility']);
-				}
-			},
 			'after_open.jstree': function () {
 				me.updateItemsLook();
 			}
 		});
 	};
-
-	me.toggleEditContext = function(canShow) {
-		var $editRow = $($('.jstree-contextmenu').children()[0]);
-		if(canShow) {
-			$editRow.removeClass('hidden');
-		} else {
-			
-			$editRow.addClass('hidden');
-		}
-	}
-
-	me.toggleDeleteContext = function(canShow, toDelete, deleteChildren) {
-		var $deleteRemoveRow = $($('.jstree-contextmenu').children()[3]),
-			$deleteOrphanRow = $($('.jstree-contextmenu').children()[4]),
-			$deleteOIcon = $deleteOrphanRow.find('i'),
-			$deleteRIcon = $deleteRemoveRow.find('i'),
-			$deleteOText = $deleteOrphanRow.find('a'),
-			$deleteRText = $deleteRemoveRow.find('a');
-
-		if(canShow) {
-			$deleteOIcon.removeClass('fa-trash fa-trash-o');
-			$deleteRIcon.removeClass('fa-trash fa-trash-o');
-
-			if(toDelete){
-				if(deleteChildren){
-					$deleteRIcon.addClass('fa-trash-o');
-					var children = $deleteRText.children();
-					$deleteRText.text('Un-Mark for Delete (Delete Orphaned Children)').prepend(children);
-
-					//Hide Orphan Row, Show All Row
-					$deleteOrphanRow.addClass('hidden');
-					$deleteRemoveRow.removeClass('hidden');
-				} else {
-					$deleteOIcon.addClass('fa-trash-o');
-					var children = $deleteOText.children();
-					$deleteOText.text('Un-Mark for Delete (Orphan Children)').prepend(children);
-
-					//Hide All Row, Show Orphan Row
-					$deleteRemoveRow.addClass('hidden');
-					$deleteOrphanRow.removeClass('hidden');
-				}
-			} else {
-				$deleteOIcon.addClass('fa-trash');
-				$deleteRIcon.addClass('fa-trash');
-				var childrenO = $deleteOText.children();
-				var childrenR = $deleteRText.children();
-				$deleteOText.text('Mark for Delete (Orphan Children)').prepend(childrenO);
-				$deleteRText.text('Mark for Delete (Delete Orphaned Children)').prepend(childrenR);
-
-				//Show Both Delete Rows
-				$deleteOrphanRow.removeClass('hidden');
-				$deleteRemoveRow.removeClass('hidden');
-			}
-		} else {
-			$deleteOrphanRow.addClass('hidden');
-			$deleteRemoveRow.addClass('hidden');
-		}
-	}
-
-	me.toggleOrphanContext = function(canShow) {
-		var $orphanRow = $($('.jstree-contextmenu').children()[1]);
-		if(canShow) {
-			$orphanRow.removeClass('hidden');
-		} else {
-			$orphanRow.addClass('hidden');
-		}
-	}
-
-	me.toggleHighlightContext = function(canShow, highlighted) {
-		var $highlightRow = $($('.jstree-contextmenu').children()[5]),
-			$highlightIcon = $highlightRow.find('i'),
-			$highlightText = $highlightRow.find('a');
-
-		if(canShow) {
-			$highlightIcon.removeClass('fa-circle fa-circle-o');
-			if(highlighted){
-				$highlightIcon.addClass('fa-circle-o');
-				var children = $highlightText.children();
-				$highlightText.text('Un-Highlight Copies').prepend(children);
-			} else {
-				$highlightIcon.addClass('fa-circle');
-				var children = $highlightText.children();
-				$highlightText.text('Highlight Copies').prepend(children);
-			}
-			$highlightRow.removeClass('hidden');
-		} else {
-			$highlightRow.addClass('hidden');
-		}
-		
-	}
-
-	me.toggleVisibilityContext = function(canShow, displayed) {
-		var $visibilityRow = $($('.jstree-contextmenu').children()[6]),
-			$visibilityIcon = $visibilityRow.find('i');
-
-		if (canShow) {
-			$visibilityIcon.removeClass('fa-eye fa-eye-slash');
-			if (displayed) {
-				$visibilityIcon.addClass('fa-eye');
-			} else {
-				$visibilityIcon.addClass('fa-eye-slash');
-			}
-			$visibilityRow.removeClass('hidden');
-		} else {
-			$visibilityRow.addClass('hidden');
-		}
-	}
-
-	me.canShowVisibilityRow = function(node){
-		if (node.parent && node.parent !== 'uber' && node.parent !== 'root' && node.parent !== 'orphans' && node.parent !== '#' && node.parents.includes('uber')) {
-			return true;
-		}
-		return false;
-	}
-
-	me.canShowOrphanRow = function(node){
-		if(node.parents.includes('uber') || node.parents.length > 3) {
-			return true;
-		}
-		return false;
-	}
-
-	me.canShowDeleteRows = function(node){
-		if(node.parents.includes('orphans') && node.parents.length == 3) {
-			return true;
-		}
-		return false;
-	}
-
-	me.deleteContextAction = function(deleteChildren){
-		var tree = CCH.ui.getTree(),
-			selectedIds = tree.get_selected();
-		var processedItems = [];
-
-		for(var i = 0; i < selectedIds.length; i++){
-			var selectedId = selectedIds[i],
-				node = tree.get_node(selectedId),
-				originalId = node.state['original-id'];
-			
-			if(!processedItems.includes(originalId)){
-				//Add this item to the processed items list so we don't process any copies of node which would undo these actions
-				processedItems.push(originalId);
-
-				if(selectedId.toLowerCase() !== 'uber' && selectedId.toLowerCase() !== 'orphans') {
-					if(me.isNodeItemOrphaned(selectedId)) {
-						var itemNodes = me.findNodesByItemId(originalId);
-
-						//Mark item and all duplicates for Delete
-						for(var j = 0; j < itemNodes.length; j++){
-							var curNode = itemNodes[j];
-							curNode.state['to-delete'] = !curNode.state['to-delete'];
-							curNode.state['delete-children'] = deleteChildren;
-						}
-						
-						me.markDeleteNodes();
-					} else {
-						//Display message that it's not an orphan
-						alert("There are copies of a selected item in the tree which are not orphans. In order to delete the selected items all copies must also be orphaned.");
-					}
-				}
-			}
-		}
-	}
 
 	me.isNodeOrphaned = function(nodeId) {
 		var tree = CCH.ui.getTree(),
@@ -554,9 +552,9 @@ CCH.Objects.Publish.Tree.UI = function (args) {
 			allChildren = tree.get_node('root').children_d,
 			nodes = [];
 
-		for(var i = 0; i < allChildren.length; i++){
+		for (var i = 0; i < allChildren.length; i++){
 			var childNode = tree.get_node(allChildren[i]);
-			if(childNode.state['original-id'] === itemId) {
+			if (childNode.state['original-id'] === itemId) {
 				nodes.push(childNode);
 			}
 		}
@@ -567,9 +565,7 @@ CCH.Objects.Publish.Tree.UI = function (args) {
 	me.isNodeItemOrphaned = function(nodeId) {
 		var isOrphan = false;
 
-		if(nodeId.toLowerCase() !== 'uber' && nodeId.toLowerCase() !== 'orphans'
-			&& nodeId.toLowerCase() !== '#' && nodeId.toLowerCase() !== 'root') {
-
+		if (!me.rootItems.includes(nodeId)) {
 			var tree = CCH.ui.getTree(),
 				node = tree.get_node(nodeId),
 				originalId = node.state['original-id'],
@@ -577,9 +573,9 @@ CCH.Objects.Publish.Tree.UI = function (args) {
 			
 			isOrphan = true;
 
-			for(var i = 0; i < allChildren.length; i++){
+			for (var i = 0; i < allChildren.length; i++){
 				var childNode = tree.get_node(allChildren[i]);
-				if(childNode.state['original-id'] === originalId && childNode !== node && childNode.parent.toLowerCase() !== 'orphans') {
+				if (childNode.state['original-id'] === originalId && childNode !== node && childNode.parent.toLowerCase() !== 'orphans') {
 					isOrphan = false;
 					break;
 				}
@@ -596,7 +592,7 @@ CCH.Objects.Publish.Tree.UI = function (args) {
 			allItems = uber.children_d,
 			invisClass = 'invisible-item';
 
-		if(allItems !== undefined){
+		if (allItems !== undefined){
 			for (var cIdx = 0; cIdx < allItems.length; cIdx++) {
 				var node = tree.get_node(allItems[cIdx]);
 				var $nodeElement = $('#' + node.li_attr.id + '_anchor');
@@ -624,7 +620,7 @@ CCH.Objects.Publish.Tree.UI = function (args) {
 			originalNode = CCH.ui.getTree().get_node(selectedId);
 
 		//Unhighlight highlighted
-		for(var i = 0; i < me.highlightedNodes.length; i++){
+		for (var i = 0; i < me.highlightedNodes.length; i++){
 			var node = me.highlightedNodes[i],
 				$nodeElement = $('#' + node.li_attr.id + '_anchor');
 			
@@ -633,7 +629,7 @@ CCH.Objects.Publish.Tree.UI = function (args) {
 
 		//Highlight new nodes
 		me.highlightedNodes = newNodes;
-		for(var i = 0; i < me.highlightedNodes.length; i++){
+		for (var i = 0; i < me.highlightedNodes.length; i++){
 			var node = me.highlightedNodes[i],
 				$nodeElement = $('#' + node.li_attr.id + '_anchor');
 	
@@ -655,12 +651,12 @@ CCH.Objects.Publish.Tree.UI = function (args) {
 			orphans = tree.get_node('orphans'),
 			orphanNodes = orphans.children;
 		
-		for(var i = 0; i < orphanNodes.length; i++){
+		for (var i = 0; i < orphanNodes.length; i++){
 			var node = tree.get_node(orphanNodes[i]),
 				$nodeElement = $('#' + node.li_attr.id + '_anchor');
 			
-			if(node.state['to-delete']){
-				if(node.state['delete-children']){
+			if (node.state['to-delete']){
+				if (node.state['delete-children']){
 					$nodeElement.addClass(deleteRClass);
 				} else {
 					$nodeElement.addClass(deleteOClass);
@@ -675,7 +671,7 @@ CCH.Objects.Publish.Tree.UI = function (args) {
 	me.highlightNodes = function() {
 		var highlightClass = 'highlight-item';
 
-		for(var i = 0; i < me.highlightedNodes.length; i++){
+		for (var i = 0; i < me.highlightedNodes.length; i++){
 			var node = me.highlightedNodes[i],
 				$nodeElement = $('#' + node.li_attr.id + '_anchor');
 	
@@ -689,7 +685,7 @@ CCH.Objects.Publish.Tree.UI = function (args) {
 			allItems = root.children_d,
 			searchClass = 'jstree-search';
 
-		if(allItems !== undefined){
+		if (allItems !== undefined){
 			for (var cIdx = 0; cIdx < allItems.length; cIdx++) {
 				var node = tree.get_node(allItems[cIdx]);
 				var $nodeElement = $('#' + node.li_attr.id + '_anchor');
@@ -701,46 +697,6 @@ CCH.Objects.Publish.Tree.UI = function (args) {
 			console.log(tree);
 		}		
 	}
-
-	/*
-	// When a user hits save, I need to reconstruct the data into the same format
-	// as when it came in. This is an iterative process that requires me to dive
-	// into each child item. Eventually, out comes a fully built out data set
-	// that reflects what the tree currently looks like
-	me.buildDataFromJsTreeData = function (data, node, tree) {
-		var nodeId = node.id,
-			children = [],
-			deleteWithChildren = [],
-			deleteOrphanChildren = [];
-
-		if (data === undefined) {
-			data = {};
-		}
-
-		if (node.children && node.children.length) {
-			for (var cIdx = 0; cIdx < node.children.length; cIdx++) {
-				var child = node.children[cIdx];
-
-				//If this item is marked to be deleted then don't include it in the children list
-				if(!child.state['to-delete']){
-					var childData = me.buildDataFromJsTreeData(null, tree.get_node(child), tree);
-					children.push(childData);
-				} else {
-
-				}
-				
-			}
-		}
-
-		data.id = nodeId;
-		data.children = children;
-		data.title = node.state.title;
-		data.itemType = node.state.itemType;
-		data.displayedChildren = node.state.displayedChildren;
-
-		return data;
-	};
-	*/
 
 	me.updateRandomIdToOriginalId = function (data) {
 		var dataClone = Object.clone(data, true);
@@ -778,10 +734,10 @@ CCH.Objects.Publish.Tree.UI = function (args) {
 		var toOrphanChildren = [];
 		var orphans = tree.get_node('orphans').children;
 
-		for(var i = 0; i < orphans.length; i++){
+		for (var i = 0; i < orphans.length; i++){
 			var orphanNode = tree.get_node(orphans[i]);
-			if(orphanNode.state['to-delete']){
-				if(orphanNode.state['delete-children']){
+			if (orphanNode.state['to-delete']){
+				if (orphanNode.state['delete-children']){
 					toDeleteChildren.push(orphanNode.state['original-id']);
 				} else {
 					toOrphanChildren.push(orphanNode.state['original-id']);

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/publish/tree/UI.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/publish/tree/UI.js
@@ -806,14 +806,14 @@ CCH.Objects.Publish.Tree.UI = function (args) {
 				alert("An error occurred while saving the tree. Some changes may have been applied. Please report this error to the CCH team and " + 
 					  "refresh the page to see the accurate current state of the tree. Error: " + JSON.stringify(error));
 					
-				$me.$saveButton.addClass('disabled');
+				me.$saveButton.addClass('disabled');
 			}
 		});
 	};
 
 	// User wants to perform a search in the tree
 	me.performTreeSearch = function (evt) {
-		var searchCriteria = evt.target.value,
+		var searchCriteria = me.$searchInput.val,
 				tree = CCH.ui.getTree();
 
 		if (searchCriteria) {

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/publish/tree/UI.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/publish/tree/UI.js
@@ -130,7 +130,7 @@ CCH.Objects.Publish.Tree.UI = function (args) {
 						}
 					},
 					'delete-all': {
-						'label': 'Remove All Copies',
+						'label': 'Remove Copies',
 						'icon': 'fa fa-eraser',
 						'action': function () {
 							var tree = CCH.ui.getTree(),
@@ -802,8 +802,11 @@ CCH.Objects.Publish.Tree.UI = function (args) {
 			success: function () {
 				location.reload();
 			},
-			error: function () {
-
+			error: function (error) {
+				alert("An error occurred while saving the tree. Some changes may have been applied. Please report this error to the CCH team and " + 
+					  "refresh the page to see the accurate current state of the tree. Error: " + JSON.stringify(error));
+					
+				$me.$saveButton.addClass('disabled');
 			}
 		});
 	};
@@ -860,7 +863,7 @@ CCH.Objects.Publish.Tree.UI = function (args) {
 		me.$clearSearchButton.on('click', me.clearSearch);
 
 		// Bind the search box
-		me.$searchInput.on('keyup', me.performTreeSearch);
+		me.$searchButton.on('click', me.performTreeSearch);
 	};
 
 	me.init();

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/publish/tree/UI.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/publish/tree/UI.js
@@ -813,7 +813,7 @@ CCH.Objects.Publish.Tree.UI = function (args) {
 
 	// User wants to perform a search in the tree
 	me.performTreeSearch = function (evt) {
-		var searchCriteria = me.$searchInput.val,
+		var searchCriteria = me.$searchInput.val(),
 				tree = CCH.ui.getTree();
 
 		if (searchCriteria) {

--- a/coastal-hazards-portal/src/main/webapp/less/publish/tree.less
+++ b/coastal-hazards-portal/src/main/webapp/less/publish/tree.less
@@ -4,8 +4,13 @@ a {
 	&.invisible-item {
 		color: #9d9d9d !important;
 	}
+
+	&.highlight-item {
+		color: #56df28 !important;
+	}
 }
 
 #search-input {
 	margin: 10px;
+	vertical-align: middle;
 }

--- a/coastal-hazards-portal/src/main/webapp/less/publish/tree.less
+++ b/coastal-hazards-portal/src/main/webapp/less/publish/tree.less
@@ -17,7 +17,7 @@ a {
 	}
 
 	&.highlight-item {
-		color: #56df28 !important;
+		background-color: #56df28 !important;
 	}
 }
 

--- a/coastal-hazards-portal/src/main/webapp/less/publish/tree.less
+++ b/coastal-hazards-portal/src/main/webapp/less/publish/tree.less
@@ -3,6 +3,17 @@
 a {
 	&.invisible-item {
 		color: #9d9d9d !important;
+		text-shadow: -1px 1px 1px black;
+	}
+
+	&.delete-orphan {
+		color: orange !important;
+		text-decoration-line: line-through !important;
+	}
+
+	&.delete-children {
+		color: red !important;
+		text-decoration-line: line-through !important;
 	}
 
 	&.highlight-item {

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
 		<version.jquery>2.1.1</version.jquery>
 		<version.jquery.ui>1.11.1</version.jquery.ui>
 		<version.bootstrap>3.3.4</version.bootstrap>
-		<version.fontawesome>4.3.0</version.fontawesome>
+		<version.fontawesome>4.7.0</version.fontawesome>
 		<version.openlayers>2.13.1</version.openlayers>
 		<gs.version>2.10.2</gs.version>
 		<gt.version>16.2</gt.version>
@@ -392,7 +392,7 @@
 			<dependency>
 				<groupId>org.webjars</groupId>
 				<artifactId>font-awesome</artifactId>
-				<version>${version.fontawesome}-1</version>
+				<version>${version.fontawesome}</version>
 			</dependency>
 			<dependency>
 				<groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
This is a pretty massive PR that touches a lot of different pieces so definitely going to want to test it very thoroughly.

Summary of Changes (may have missed some other small pieces):

UI:
- Added "Mark for Delete (Orphan Children)" and "Mark for Delete (Delete Orphaned Children)" context menu items to the tree view.
- Added "Highlight Copies" context menu item to the tree view.
- Added "Remove Copies" context menu item to the tree view.
- Adjusted move item logic in the tree view to prevent moving items outside of Uber or Orphans and prevent moving multiple copies of items underneath the same parent.
- Adjusted copy item logic in the tree view to prevent copying items to outside of Uber or Orphans, copying items into Orphans, or copying an item to a parent that already contains a copy of that item.
- Adjusted post-copy item tree behavior to allow interacting with the newly created node
- Adjusted the context menu to only show rows that are applicable to the slected item
- Fixed behavior of orphan context menu entry to allow orphaning multiple selected items at once
- Added the ability to delete multiple selected items at once
- Updated the context menu to only list rows that are relevant to ALL selected items in order to prevent performing actions on items that should not allow them
- Added basic (browser alert) tree save error reporting
- Added basic (browser alert) hints when trying to mark items for delete that have non-orphaned copies
- Updated tree view select behavior to prevent selecting Uber, Orphans, and Root
- Updated Font Awesome to version 4.7 from 4.1 to add additional icons (particularly fa-uesr-o)
- Removed the call to delete aliases from the item edit page delete button as that is now handled server side when an item is deleted.
- Added a "Clear Search" button to the search bar
- Adjusted the styling of items marked as non-visible so that it's possible to indicate an item is to be deleted, highlighted, found by the search, and non-visible all simultaneously.
- Adjusted the search box to run when a newly added "Search" button is pressed rather than on "key up" because it takes a very long time for it to execute when the first few letters of the search are typed and there are a large number of items.

Server:
- Added support for deletes in the tree save endpoint
- Adjusted `isOrphan` check to only count an item as an orphan if it has NO items that claim it as a child, including other orphaned items.
- Slight refactor and cleanup of item delete logic
- Better logging of errors when deleting items
- Added support for deleting an item from all sessions
- Added support for deleting data domains by an item ID
- Added a step in the item delete process to remove rows from non-related (foreign-key constrained) tables that reference the item to be deleted (Aliases, Data Domains, and Session Items)