### PR TITLE
CCHS-444: Allow management of NHC NOAA layers for RTS outside of software release 

### DIFF
--- a/coastal-hazards-portal/docker/context.xml
+++ b/coastal-hazards-portal/docker/context.xml
@@ -55,10 +55,10 @@
     <Environment name="coastal-hazards.portal.geoserver.cache.name" type="java.lang.String" value="${cch_geoserver_cache_name}" />
 
     <!-- NHC Track Item Defauls -->
-    <Environment name="coastal-hazards.nhc.track.bbox.north" type="java.lang.Double" value="45.95"/>
-    <Environment name="coastal-hazards.nhc.track.bbox.west" type="java.lang.Double" value="-101.84"/>
-    <Environment name="coastal-hazards.nhc.track.bbox.east" type="java.lang.Double" value="-62.4"/>
-    <Environment name="coastal-hazards.nhc.track.bbox.south" type="java.lang.Double" value="17.64"/>
+    <Environment name="coastal-hazards.nhc.track.bbox.north" type="java.lang.String" value="45.95"/>
+    <Environment name="coastal-hazards.nhc.track.bbox.west" type="java.lang.String" value="-101.84"/>
+    <Environment name="coastal-hazards.nhc.track.bbox.east" type="java.lang.String" value="-62.4"/>
+    <Environment name="coastal-hazards.nhc.track.bbox.south" type="java.lang.String" value="17.64"/>
     <Environment name="coastal-hazards.nhc.track.wms" type="java.lang.String" value="http://nowcoast.noaa.gov/arcgis/services/nowcoast/wwa_meteocean_tropicalcyclones_trackintensityfcsts_time/MapServer/WmsServer?"/>
     <Environment name="coastal-hazards.nhc.track.attrs" type="java.lang.String" value="NHC_TRACK_POLY|NHC_TRACK_LIN|NHC_TRACK_PT"/>
     <Environment name="coastal-hazards.nhc.track.attr.params" type="java.lang.String" value="6|3|8,7,4"/>

--- a/coastal-hazards-portal/docker/context.xml
+++ b/coastal-hazards-portal/docker/context.xml
@@ -53,4 +53,21 @@
     <Environment name="coastal-hazards.geoserver.workspaces.permanent" type="java.lang.String" value="${cch_geoserver_workspace_permanent}"/>
     <Environment name="coastal-hazards.workspace.published" type="java.lang.String" value="${cch_geoserver_workspace_published}"/>
     <Environment name="coastal-hazards.portal.geoserver.cache.name" type="java.lang.String" value="${cch_geoserver_cache_name}" />
+
+    <!-- NHC Track Item Defauls -->
+    <Environment name="coastal-hazards.nhc.track.bbox.north" type="java.lang.Double" value="45.95"/>
+    <Environment name="coastal-hazards.nhc.track.bbox.west" type="java.lang.Double" value="-101.84"/>
+    <Environment name="coastal-hazards.nhc.track.bbox.east" type="java.lang.Double" value="-62.4"/>
+    <Environment name="coastal-hazards.nhc.track.bbox.south" type="java.lang.Double" value="17.64"/>
+    <Environment name="coastal-hazards.nhc.track.wms" type="java.lang.String" value="http://nowcoast.noaa.gov/arcgis/services/nowcoast/wwa_meteocean_tropicalcyclones_trackintensityfcsts_time/MapServer/WmsServer?"/>
+    <Environment name="coastal-hazards.nhc.track.attrs" type="java.lang.String" value="NHC_TRACK_POLY|NHC_TRACK_LIN|NHC_TRACK_PT"/>
+    <Environment name="coastal-hazards.nhc.track.attr.params" type="java.lang.String" value="6|3|8,7,4"/>
+    <Environment name="coastal-hazards.nhc.track.tiny.text" type="java.lang.String" value="NWS NHC Forecasted Tropical Cyclone"/>
+    <Environment name="coastal-hazards.nhc.track.med.title" type="java.lang.String" value="NWS NHC Forecast"/>
+    <Environment name="coastal-hazards.nhc.track.med.text" type="java.lang.String" value="The latest Tropical Cyclone Forecast from the NWS National Hurricane Center (NHC), updated hourly."/>
+    <Environment name="coastal-hazards.nhc.track.full.title" type="java.lang.String" value="NWS NHC Forecasted Tropical Cyclone"/>
+    <Environment name="coastal-hazards.nhc.track.full.text" type="java.lang.String" value="The nowCOAST 'wwa' Web Map Service (WMS) provides layers containing near real-time watches, warnings and advisories from the National Weather Service (NWS).  This layer shows the latest Tropical Cyclone Track and Cone Forecast from the NWS National Hurricane Center (NHC), updated hourly. The 'wwa' WMS is one of several map services provided by NOAA's nowCOAST project (http://nowcoast.noaa.gov), a product of the NOAA/NOS/OCS Coast Survey Development Laboratory."/>
+    <Environment name="coastal-hazards.nhc.track.keywords" type="java.lang.String" value="Hurricane|Track|NOAA|nowCOAST"/>
+    <Environment name="coastal-hazards.nhc.track.res.titles" type="java.lang.String" value="NOAA's nowCOAST"/>
+    <Environment name="coastal-hazards.nhc.track.res.links" type="java.lang.String" value="https://nowcoast.noaa.gov/"/>
 </Context>

--- a/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/rest/data/util/StormUtil.java
+++ b/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/rest/data/util/StormUtil.java
@@ -1,10 +1,5 @@
 package gov.usgs.cida.coastalhazards.rest.data.util;
 
-import gov.usgs.cida.coastalhazards.jpa.ItemManager;
-import gov.usgs.cida.coastalhazards.model.Bbox;
-import gov.usgs.cida.coastalhazards.model.Item;
-import gov.usgs.cida.coastalhazards.model.Item.ItemType;
-import gov.usgs.cida.coastalhazards.model.Item.Type;
 import gov.usgs.cida.coastalhazards.model.Layer;
 import gov.usgs.cida.coastalhazards.model.Service.ServiceType;
 import gov.usgs.cida.coastalhazards.model.Service;
@@ -13,13 +8,8 @@ import gov.usgs.cida.coastalhazards.model.summary.Legend;
 import gov.usgs.cida.coastalhazards.model.summary.Medium;
 import gov.usgs.cida.coastalhazards.model.summary.Summary;
 import gov.usgs.cida.coastalhazards.model.summary.Tiny;
-import gov.usgs.cida.coastalhazards.model.summary.Publication.PublicationType;
-import gov.usgs.cida.utilities.IdGenerator;
-import gov.usgs.cida.coastalhazards.model.summary.Publication;
 import java.io.ByteArrayInputStream;
-import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -196,7 +186,7 @@ public class StormUtil {
         return cswService;
     }
 
-    public static Map<String, Object> createStormChildMap(String layerId) {
+    public static Map<String, Object> createStormChildMap(String layerId, boolean active, String trackId) {
         Map<String, Object> childMap = new HashMap<>();
         List< Map<String, Object> > childList = new ArrayList<>();
         final String attrKey = "attr";
@@ -212,209 +202,52 @@ public class StormUtil {
         Map<String, Object> extremeChild = new HashMap<>();
         Map<String, Object> trackChild = new HashMap<>();
 
-        Item track = saveStormTrack();
+        pcolChild.put(attrKey, "PCOL");
+        pcolChild.put(layerIdKey, layerId);
+        pcolChild.put(visibleKey, true);
+        childList.add(pcolChild);
 
-        if(track != null) {
-            pcolChild.put(attrKey, "PCOL");
-            pcolChild.put(layerIdKey, layerId);
-            pcolChild.put(visibleKey, true);
-            childList.add(pcolChild);
+        povwChild.put(attrKey, "POVW");
+        povwChild.put(layerIdKey, layerId);
+        povwChild.put(visibleKey, true);
+        childList.add(povwChild);
 
-            povwChild.put(attrKey, "POVW");
-            povwChild.put(layerIdKey, layerId);
-            povwChild.put(visibleKey, true);
-            childList.add(povwChild);
+        pindChild.put(attrKey, "PIND");
+        pindChild.put(layerIdKey, layerId);
+        pindChild.put(visibleKey, true);
+        childList.add(pindChild);
 
-            pindChild.put(attrKey, "PIND");
-            pindChild.put(layerIdKey, layerId);
-            pindChild.put(visibleKey, true);
-            childList.add(pindChild);
+        dhighChild.put(attrKey, "DHIGH");
+        dhighChild.put(layerIdKey, layerId);
+        dhighChild.put(visibleKey, false);
+        childList.add(dhighChild);
 
-            dhighChild.put(attrKey, "DHIGH");
-            dhighChild.put(layerIdKey, layerId);
-            dhighChild.put(visibleKey, false);
-            childList.add(dhighChild);
+        dlowChild.put(attrKey, "DLOW");
+        dlowChild.put(layerIdKey, layerId);
+        dlowChild.put(visibleKey, false);
+        childList.add(dlowChild);
 
-            dlowChild.put(attrKey, "DLOW");
-            dlowChild.put(layerIdKey, layerId);
-            dlowChild.put(visibleKey, false);
-            childList.add(dlowChild);
+        meanChild.put(attrKey, "MEAN");
+        meanChild.put(layerIdKey, layerId);
+        meanChild.put(visibleKey, false);
+        childList.add(meanChild);
 
-            meanChild.put(attrKey, "MEAN");
-            meanChild.put(layerIdKey, layerId);
-            meanChild.put(visibleKey, false);
-            childList.add(meanChild);
+        extremeChild.put(attrKey, "EXTREME");
+        extremeChild.put(layerIdKey, layerId);
+        extremeChild.put(visibleKey, false);
+        childList.add(extremeChild);
 
-            extremeChild.put(attrKey, "EXTREME");
-            extremeChild.put(layerIdKey, layerId);
-            extremeChild.put(visibleKey, false);
-            childList.add(extremeChild);
-
-            trackChild.put("id", track.getId());
+        if(active && trackId != null && trackId.length() > 0) {
+            trackChild.put("id", trackId);
             trackChild.put(visibleKey, true);
             childList.add(trackChild);
-
-            childMap.put("children", childList);
+        } else if(active) {
+            log.error("Storm is active but no track ID provided.");
+            return null;
         }
+
+        childMap.put("children", childList);
         
         return childMap;
-    }
-
-    private static Item saveStormTrack() {
-        Item stormTrack = null;
-
-        //If the Storm Track item has not yet been created then create it
-        try(ItemManager manager = new ItemManager()) {
-            stormTrack = manager.load(STORM_TRACK_ITEM_ID);
-        }
-
-        if(stormTrack == null) {
-            stormTrack = baseTrackItem();
-            stormTrack.setId(STORM_TRACK_ITEM_ID);
-            stormTrack.setItemType(ItemType.aggregation);
-            stormTrack.setShowChildren(true);
-            stormTrack.setChildren(trackChildren());
-
-            if(stormTrack.getChildren() != null) {
-                List<String> childIds = new ArrayList<>();
-                for(Item child : stormTrack.getChildren()) {
-                    childIds.add(child.getId());
-                }
-
-                stormTrack.setDisplayedChildren(childIds);
-                stormTrack = saveTrackItem(stormTrack);
-            } else {
-                stormTrack = null;
-            }
-        }
-
-        return stormTrack;
-    }
-
-    private static Summary trackSummary() {
-        Summary stormSummary = new Summary();
-        stormSummary.setTiny(new Tiny());
-        stormSummary.setMedium(new Medium());
-        stormSummary.setFull(new Full());
-
-        stormSummary.getTiny().setText("NWS NHC Forecasted Tropical Cyclone");
-        stormSummary.getMedium().setTitle("NWS NHC Forecast");
-        stormSummary.getMedium().setText("The latest Tropical Cyclone Forecast from the NWS National Hurricane Center (NHC), updated hourly.");
-        stormSummary.getFull().setTitle("NWS NHC Forecasted Tropical Cyclone");
-        stormSummary.getFull().setText("The nowCOAST 'wwa' Web Map Service (WMS) provides layers containing near real-time watches, warnings " +
-                                        "and advisories from the National Weather Service (NWS).  This layer shows the latest Tropical Cyclone " +
-                                        "Track and Cone Forecast from the NWS National Hurricane Center (NHC), updated hourly. The 'wwa' WMS " +
-                                        "is one of several map services provided by NOAA's nowCOAST project (http://nowcoast.noaa.gov), a " +
-                                        "product of the NOAA/NOS/OCS Coast Survey Development Laboratory.");
-        stormSummary.getFull().setPublications(trackSummaryPublications());
-        stormSummary.setKeywords("Hurricane|Track|NOAA|nowCOAST");
-
-        return stormSummary;
-    }
-
-    private static List<Publication> trackSummaryPublications() {
-        List<Publication> publications = new ArrayList<>();
-        Publication nowCoast = new Publication();
-
-        nowCoast.setType(PublicationType.resources);
-        nowCoast.setTitle("NOAA's nowCOAST");
-        nowCoast.setLink("https://nowcoast.noaa.gov/");
-
-        publications.add(nowCoast);
-        
-        return publications;
-    }
-
-    private static Bbox trackBbox() {
-        Bbox stormBbox = new Bbox();
-        stormBbox.setBbox(-101.8, 17.6, -62.4, 46.0);
-        return stormBbox;
-    }
-
-    private static List<Service> trackChildServices(String serviceParam) {
-        List<Service> childServices = new ArrayList<>();
-
-        Service sourceWms = new Service();
-        sourceWms.setEndpoint("http://nowcoast.noaa.gov/arcgis/services/nowcoast/wwa_meteocean_tropicalcyclones_trackintensityfcsts_time/MapServer/WmsServer?");
-        sourceWms.setType(ServiceType.source_wms);
-        sourceWms.setServiceParameter(serviceParam);
-
-        Service proxyWms = new Service();
-        sourceWms.setEndpoint("http://nowcoast.noaa.gov/arcgis/services/nowcoast/wwa_meteocean_tropicalcyclones_trackintensityfcsts_time/MapServer/WmsServer?");
-        sourceWms.setType(ServiceType.proxy_wms);
-        sourceWms.setServiceParameter(serviceParam);
-
-        childServices.add(sourceWms);
-        childServices.add(proxyWms);
-
-        return childServices;
-    }
-
-    private static List<Item> trackChildren() {
-        List<Item> children = null;
-
-        Item polyChild = baseTrackItem();
-        polyChild.setId(IdGenerator.generate());
-        polyChild.setItemType(ItemType.data);
-        polyChild.setAttr("NHC_TRACK_POLY");
-        polyChild.setServices(trackChildServices("6"));
-        polyChild = saveTrackItem(polyChild);
-
-        Item linChild = baseTrackItem();
-        linChild.setId(IdGenerator.generate());
-        linChild.setItemType(ItemType.data);
-        linChild.setAttr("NHC_TRACK_LIN");
-        linChild.setServices(trackChildServices("3"));
-        linChild = saveTrackItem(linChild);
-
-        Item ptChild = baseTrackItem();
-        ptChild.setId(IdGenerator.generate());
-        ptChild.setItemType(ItemType.data);
-        ptChild.setAttr("NHC_TRACK_PT");
-        ptChild.setServices(trackChildServices("8,7,4"));
-        ptChild = saveTrackItem(ptChild);
-
-        if(polyChild != null && linChild != null && ptChild != null) {
-            children = new ArrayList<>();
-            children.add(polyChild);
-            children.add(linChild);
-            children.add(ptChild);
-        }
-
-        return children;
-    }
-
-    private static Item baseTrackItem() {
-        Item baseItem = new Item();
-
-        baseItem.setName("track");
-        baseItem.setType(Type.storms);
-        baseItem.setActiveStorm(false);
-        baseItem.setRibbonable(false);
-        baseItem.setShowChildren(true);
-        baseItem.setFeatured(false);
-        baseItem.setEnabled(true);
-        baseItem.setLastModified(Date.from(Instant.now()));
-        baseItem.setBbox(Bbox.copyValues(trackBbox(), new Bbox()));
-        baseItem.setSummary(trackSummary());
-
-        return baseItem;
-    }
-
-    private static Item saveTrackItem(Item toSave) {
-        String id = null;
-        Item saved = null;
-
-        try(ItemManager manager = new ItemManager()) {
-            id = manager.persist(toSave);
-
-            if(id != null) {
-                saved = manager.load(id);
-            }
-        } catch (Exception e) {
-            log.error(e.getMessage() + "\nStack Trace: " + e.getStackTrace());
-        }
-        
-        return saved;
     }
 }

--- a/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/publish/item/index.jsp
+++ b/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/publish/item/index.jsp
@@ -919,7 +919,7 @@
                                         <br/>
                                         <button class="btn" type="button" data-toggle="collapse" data-target="#storm-nhc-resources-res" aria-expanded="false" aria-controls="storm-nhc-resources-res">G). Resources - Resources</button>
                                         <div class="collapse" id="storm-nhc-resources-res">
-                                            <label for="storm-nhc-child-attr">G-a). Resrouces - Resource Titles</label>
+                                            <label for="storm-nhc-child-attr">G-a). Resources - Resource Titles</label>
                                             <div class="storm-modal-nhc-text-desc">One Resource will be created per title. Titles should be separated by |.</div>
                                             <input type="text" class="form-control storm-modal-nhc-text" id="storm-nhc-res-titles" name="storm-nhc-res-titles" value="<%=nhcTrackResTitles%>"/>
                                             <br/>

--- a/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/publish/item/index.jsp
+++ b/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/publish/item/index.jsp
@@ -59,6 +59,7 @@
     String nhcTrackMedText = getProp("coastal-hazards.nhc.track.med.text");
     String nhcTrackFullTitle = getProp("coastal-hazards.nhc.track.full.title");
     String nhcTrackFullText = getProp("coastal-hazards.nhc.track.full.text");
+    String nhcTrackKeywords = getProp("coastal-hazards.nhc.track.keywords");
     String nhcTrackDataTitles = getProp("coastal-hazards.nhc.track.data.titles");
     String nhcTrackDataLinks = getProp("coastal-hazards.nhc.track.data.links");
     String nhcTrackPubTitles = getProp("coastal-hazards.nhc.track.pub.titles");
@@ -878,6 +879,9 @@
                                             <br/>
                                             <label for="storm-nhc-sum-full-text">D-e). Summary - Full Text</label>
                                             <textarea class="form-control storm-modal-nhc-text" id="storm-nhc-sum-full-text" rows="4" maxlength="64000" name="storm-nhc-sum-full-text"><%=nhcTrackFullText%></textarea>
+                                            <br/>
+                                            <label for="storm-nhc-sum-keywords">D-f). Summary - Keywords</label>
+                                            <textarea class="form-control storm-modal-nhc-text" id="storm-nhc-sum-keywords" rows="4" maxlength="64000" name="storm-nhc-sum-keywords"><%=nhcTrackKeywords%></textarea>
                                         </div>
                                         <br/>
                                         <br/>

--- a/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/publish/item/index.jsp
+++ b/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/publish/item/index.jsp
@@ -47,10 +47,10 @@
     String baseUrl = props.getProperty("coastal-hazards.base.secure.url");
     baseUrl = StringUtils.isNotBlank(baseUrl) ? baseUrl : request.getContextPath();
 
-    double nhcTrackBboxNorth = Double.parseDouble(getProp("coastal-hazards.nhc.track.bbox.north"));
-    double nhcTrackBboxWest = Double.parseDouble(getProp("coastal-hazards.nhc.track.bbox.west"));
-    double nhcTrackBboxEast = Double.parseDouble(getProp("coastal-hazards.nhc.track.bbox.east"));
-    double nhcTrackBboxSouth = Double.parseDouble(getProp("coastal-hazards.nhc.track.bbox.south"));
+    String nhcTrackBboxNorth = getProp("coastal-hazards.nhc.track.bbox.north");
+    String nhcTrackBboxWest = getProp("coastal-hazards.nhc.track.bbox.west");
+    String nhcTrackBboxEast = getProp("coastal-hazards.nhc.track.bbox.east");
+    String nhcTrackBboxSouth = getProp("coastal-hazards.nhc.track.bbox.south");
     String nhcTrackWmsUrl = getProp("coastal-hazards.nhc.track.wms");
     String nhcTrackAttrs = getProp("coastal-hazards.nhc.track.attrs");
     String nhcTrackAttrParams = getProp("coastal-hazards.nhc.track.attr.params");

--- a/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/publish/item/index.jsp
+++ b/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/publish/item/index.jsp
@@ -47,6 +47,25 @@
     String baseUrl = props.getProperty("coastal-hazards.base.secure.url");
     baseUrl = StringUtils.isNotBlank(baseUrl) ? baseUrl : request.getContextPath();
 
+    double nhcTrackBboxNorth = Double.parseDouble(getProp("coastal-hazards.nhc.track.bbox.north"));
+    double nhcTrackBboxWest = Double.parseDouble(getProp("coastal-hazards.nhc.track.bbox.west"));
+    double nhcTrackBboxEast = Double.parseDouble(getProp("coastal-hazards.nhc.track.bbox.east"));
+    double nhcTrackBboxSouth = Double.parseDouble(getProp("coastal-hazards.nhc.track.bbox.south"));
+    String nhcTrackWmsUrl = getProp("coastal-hazards.nhc.track.wms");
+    String nhcTrackAttrs = getProp("coastal-hazards.nhc.track.attrs");
+    String nhcTrackAttrParams = getProp("coastal-hazards.nhc.track.attr.params");
+    String nhcTrackTinyText = getProp("coastal-hazards.nhc.track.tiny.text");
+    String nhcTrackMedTitle = getProp("coastal-hazards.nhc.track.med.title");
+    String nhcTrackMedText = getProp("coastal-hazards.nhc.track.med.text");
+    String nhcTrackFullTitle = getProp("coastal-hazards.nhc.track.full.title");
+    String nhcTrackFullText = getProp("coastal-hazards.nhc.track.full.text");
+    String nhcTrackDataTitles = getProp("coastal-hazards.nhc.track.data.titles");
+    String nhcTrackDataLinks = getProp("coastal-hazards.nhc.track.data.links");
+    String nhcTrackPubTitles = getProp("coastal-hazards.nhc.track.pub.titles");
+    String nhcTrackPubLinks = getProp("coastal-hazards.nhc.track.pub.links");
+    String nhcTrackResTitles = getProp("coastal-hazards.nhc.track.res.titles");
+    String nhcTrackResLinks = getProp("coastal-hazards.nhc.track.res.links");
+
     // Figure out the path based on the ID passed in, if any
     Map<String, String> attributeMap = (Map<String, String>) pageContext.findAttribute("it");
     String id = attributeMap.get("id") == null ? "" : attributeMap.get("id");
@@ -137,7 +156,6 @@
         </script>
     </head>
     <body>
-
         <div class="container">
             <div class="panel panel-default">
                 <div class="panel-heading">
@@ -786,95 +804,139 @@
                                 <input type="file" name="file"/>
                             </div>
                             <br/>
-                            <div>
-                                <label for="new-active">2. Is Storm Active? <input type="checkbox" id="new-active" name="new-active"/></label>
-                                <span>Only storms marked as being active will contain an NHC Storm Track child item.</span>
-                                <div id="edit-new-track" style="/*! border: 1px solid black; */">
-                                    <br>
-                                    <label>2a).Modify NHC Storm Track</label>
-                                    <div id="storm-modal-nhc-form">
-                                        <small><div id="storm-nhc-bbox" class="">
-                                            <label for="storm-nhc-bbox-table">A). Bounding Box</label>
-                                            <label for="nhc-bbox-inherit">Inherit from Storm Shape File? <input id="nhc-bbox-inherit" name="nhc-bbox-inherit" type="checkbox"></label>
-                                            <table id="storm-nhc-bbox-table">
-                                                <tbody><tr>
-                                                    <td></td>
-                                                    <td id="storm-nhc-bbox-table-north">
-                                                        <label for="storm-nhc-bbox-input-north">North</label>
-                                                        <input id="storm-nhc-bbox-input-north" class="form-control bbox" placeholder="180" type="text">
-                                                    </td>
-                                                    <td></td>
-                                                </tr>
-                                                <tr>
-                                                    <td id="storm-nhc-bbox-table-west">
-                                                        <label for="storm-nhc-bbox-input-west">West</label>
-                                                        <input id="storm-nhc-bbox-input-west" class="form-control bbox" placeholder="-180" type="text">
-                                                    </td>
-                                                    <td></td>
-                                                    <td id="storm-nhc-bbox-table-east">
-                                                        <label for="storm-nhc-bbox-input-east">East</label>
-                                                        <input id="storm-nhc-bbox-input-east" class="form-control bbox" placeholder="180" type="text">
-                                                    </td>
-                                                </tr>
-                                                <tr>
-                                                    <td></td>
-                                                    <td id="storm-nhc-bbox-table-south">
-                                                        <label for="storm-nhc-bbox-input-south">South</label>
-                                                        <input id="storm-nhc-bbox-input-south" class="form-control bbox" placeholder="-180" type="text">
-                                                    </td>
-                                                    <td></td>
-                                                </tr>
-                                            </tbody></table>
-                                        </div></small>
-                                        <br/>
-                                        <small><div id="storm-nhc-wms" class="">
-                                            <label for="storm-nhc-wms-link">B). WMS URL</label>
-                                            <input type="text" class="form-control storm-modal-nhc-text" id="storm-nhc-wms-link" name="storm-nhc-wms-link"/>
-                                            <br/>
-                                            <label for="storm-nhc-child-attr">C). Child WMS Attributes</label>
-                                            <div class="storm-modal-nhc-text-desc">One child item will be made per specified attribute name. Attributes should be separated by |.</div>
-                                            <input type="text" class="form-control storm-modal-nhc-text" id="storm-nhc-child-attr" name="storm-nhc-child-attr"/>
-                                            <br/>
-                                            <label for="storm-nhc-child-param">D). Child WMS Attribute Parameters</label>
-                                            <div class="storm-modal-nhc-text-desc">The list of WMS parameters to provide for each child attribute. Multiple parameters may be provided per attribute, separated by commas. Attributes should be separated by |. The number of groups here should be equal to the number of attributes specified above.</div>
-                                            <input type="text" class="form-control storm-modal-nhc-text" id="storm-nhc-child-param" name="storm-nhc-child-param"/>
-                                            <br/>
-                                            <label for="storm-nhc-wms-link">E). Summary - Tiny Text</label>
-                                            <textarea class="form-control storm-modal-nhc-text" id="storm-nhc-wms-link" rows="1" maxlength="105" name="storm-nhc-wms-link"></textarea>
-                                            <br/>
-                                            <label for="storm-nhc-wms-link">F). Summary - Medium Title</label>
-                                            <textarea class="form-control storm-modal-nhc-text" id="storm-nhc-wms-link" rows="1" maxlength="1024" name="storm-nhc-wms-link"></textarea>
-                                            <br/>
-                                            <label for="storm-nhc-wms-link">G). Summary - Medium Text</label>
-                                            <textarea class="form-control storm-modal-nhc-text" id="storm-nhc-wms-link" rows="2" maxlength="2048" name="storm-nhc-wms-link"></textarea>
-                                            <br/>
-                                            <label for="storm-nhc-wms-link">H). Summary - Full Title</label>
-                                            <textarea class="form-control storm-modal-nhc-text" id="storm-nhc-wms-link" rows="1" maxlength="1024" name="storm-nhc-wms-link"></textarea>
-                                            <br/>
-                                            <label for="storm-nhc-wms-link">I). Summary - Full Text</label>
-                                            <textarea class="form-control storm-modal-nhc-text" id="storm-nhc-wms-link" rows="3" maxlength="64000" name="storm-nhc-wms-link"></textarea>
-                                        </div></small>
-                                    </div>
-                                </div>
-                            </div>
-                            <br/>
-                            <div>
-                                <label for="inherit-alias">3. Alias to Use [optional]</label>
-                                <span>If the provided Alias is already in-use by another Item it will be removed from that Item and assigned to the newly created Storm.</span>
-                                <br/>
-                                <input type="text" id="inherit-alias" name="inherit-alias"/>
-                            </div>
-                            <br/>
-                            <div>
-                                <label for="copy-type">4. Copy Existing Summary [optional]</label>
-                                <span>The Summary includes the data from the Titles/Descriptions, Keywords, and Resources (Data, Publications, and Resource entires) sections of the publish item page.</span>
-                                <br/>
-                                <label for="copy-none">None <input type="radio" name="copy-type" id="copy-none" value="none" checked/></label>
-                                <label for="copy-item">From Item <input type="radio" name="copy-type" id="copy-item" value="item"/></label>
-                                <label for="copy-alias">From Alias <input type="radio" name="copy-type" id="copy-alias" value="alias"/></label>
-                                <label for="copy-input"><span></span><input type="text" name="copy-input" hidden/></label>
-                            </div>
                         </form>
+                        <div>
+                            <label for="new-active">2. Is Storm Active? <input type="checkbox" id="new-active" name="new-active"/></label>
+                            <span>Only storms marked as being active will contain an NHC Storm Track child item.</span>
+                            <div id="edit-new-track" style="/*! border: 1px solid black; */" hidden>
+                                <br>
+                                <label>2a).Modify NHC Storm Track</label>
+                                <form id="storm-modal-nhc-form">
+                                    <small><div id="storm-nhc-bbox" class="">
+                                        <label for="storm-nhc-bbox-table">A). Bounding Box</label>
+                                        <label for="nhc-bbox-inherit">Inherit from Storm Shape File? <input id="nhc-bbox-inherit" name="nhc-bbox-inherit" type="checkbox"></label>
+                                        <table id="storm-nhc-bbox-table">
+                                            <tbody><tr>
+                                                <td></td>
+                                                <td id="storm-nhc-bbox-table-north">
+                                                    <label for="storm-nhc-bbox-input-north" class="nhc-bbox-label">North</label>
+                                                    <input id="storm-nhc-bbox-input-north" name="storm-nhc-bbox-input-north" class="form-control nhc-bbox" placeholder="180" type="text" value="<%=nhcTrackBboxNorth%>">
+                                                </td>
+                                                <td></td>
+                                            </tr>
+                                            <tr>
+                                                <td id="storm-nhc-bbox-table-west">
+                                                    <label for="storm-nhc-bbox-input-west" class="nhc-bbox-label">West</label>
+                                                    <input id="storm-nhc-bbox-input-west" name="storm-nhc-bbox-input-west" class="form-control nhc-bbox" placeholder="-180" type="text" value="<%=nhcTrackBboxWest%>">
+                                                </td>
+                                                <td></td>
+                                                <td id="storm-nhc-bbox-table-east">
+                                                    <label for="storm-nhc-bbox-input-east" class="nhc-bbox-label">East</label>
+                                                    <input id="storm-nhc-bbox-input-east" name="storm-nhc-bbox-input-east" class="form-control nhc-bbox" placeholder="180" type="text" value="<%=nhcTrackBboxEast%>">
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td></td>
+                                                <td id="storm-nhc-bbox-table-south">
+                                                    <label for="storm-nhc-bbox-input-south" class="nhc-bbox-label">South</label>
+                                                    <input id="storm-nhc-bbox-input-south" name="storm-nhc-bbox-input-south" class="form-control nhc-bbox" placeholder="-180" type="text" value="<%=nhcTrackBboxSouth%>">
+                                                </td>
+                                                <td></td>
+                                            </tr>
+                                        </tbody></table>
+                                    </div></small>
+                                    <br/>
+                                    <small><div id="storm-nhc-wms" class="">
+                                        <label for="storm-nhc-wms-link">B). WMS URL</label>
+                                        <input type="text" class="form-control storm-modal-nhc-text" id="storm-nhc-wms-link" name="storm-nhc-wms-link" value="<%=nhcTrackWmsUrl%>"/>
+                                        <br/>
+                                        <button class="btn" type="button" data-toggle="collapse" data-target="#storm-nhc-attrs" aria-expanded="false" aria-controls="storm-nhc-attrs">C). Children</button>
+                                        <div class="collapse" id="storm-nhc-attrs">
+                                            <label for="storm-nhc-child-attr">C-a). Child WMS Attributes</label>
+                                            <div class="storm-modal-nhc-text-desc">One child item will be made per specified attribute name. Attributes should be separated by |.</div>
+                                            <input type="text" class="form-control storm-modal-nhc-text" id="storm-nhc-child-attr" name="storm-nhc-child-attr" value="<%=nhcTrackAttrs%>"/>
+                                            <br/>
+                                            <label for="storm-nhc-child-param">C-b). Child WMS Attribute Parameters</label>
+                                            <div class="storm-modal-nhc-text-desc">The list of WMS parameters to provide for each child attribute. Multiple parameters may be provided per attribute, separated by commas. Attributes should be separated by |. The number of groups here should be equal to the number of attributes specified above.</div>
+                                            <input type="text" class="form-control storm-modal-nhc-text" id="storm-nhc-child-param" name="storm-nhc-child-param" value="<%=nhcTrackAttrParams%>"/>
+                                        </div>
+                                        <br/>
+                                        <br/>
+                                        <button class="btn" type="button" data-toggle="collapse" data-target="#storm-nhc-summary" aria-expanded="false" aria-controls="storm-nhc-summary">D). Summary</button>
+                                        <div class="collapse" id="storm-nhc-summary">
+                                            <label for="storm-nhc-sum-tiny-text">D-a). Summary - Tiny Text</label>
+                                            <textarea class="form-control storm-modal-nhc-text" id="storm-nhc-sum-tiny-text" rows="1" maxlength="105" name="storm-nhc-sum-tiny-text"><%=nhcTrackTinyText%></textarea>
+                                            <br/>
+                                            <label for="storm-nhc-sum-med-title">D-b). Summary - Medium Title</label>
+                                            <textarea class="form-control storm-modal-nhc-text" id="storm-nhc-sum-med-title" rows="1" maxlength="1024" name="storm-nhc-sum-med-title"><%=nhcTrackMedTitle%></textarea>
+                                            <br/>
+                                            <label for="storm-nhc-sum-med-text">D-c). Summary - Medium Text</label>
+                                            <textarea class="form-control storm-modal-nhc-text" id="storm-nhc-sum-med-text" rows="2" maxlength="2048" name="storm-nhc-sum-med-text"><%=nhcTrackMedText%></textarea>
+                                            <br/>
+                                            <label for="storm-nhc-sum-full-title">D-d). Summary - Full Title</label>
+                                            <textarea class="form-control storm-modal-nhc-text" id="storm-nhc-sum-full-title" rows="1" maxlength="1024" name="storm-nhc-sum-full-title"><%=nhcTrackFullTitle%></textarea>
+                                            <br/>
+                                            <label for="storm-nhc-sum-full-text">D-e). Summary - Full Text</label>
+                                            <textarea class="form-control storm-modal-nhc-text" id="storm-nhc-sum-full-text" rows="4" maxlength="64000" name="storm-nhc-sum-full-text"><%=nhcTrackFullText%></textarea>
+                                        </div>
+                                        <br/>
+                                        <br/>
+                                        <button class="btn" type="button" data-toggle="collapse" data-target="#storm-nhc-resources-data" aria-expanded="false" aria-controls="storm-nhc-resources-data">E). Resources - Data</button>
+                                        <div class="collapse" id="storm-nhc-resources-data">
+                                            <label for="storm-nhc-child-attr">E-a). Resources - Data Titles</label>
+                                            <div class="storm-modal-nhc-text-desc">One Data Resource will be created per title. Titles should be separated by |.</div>
+                                            <input type="text" class="form-control storm-modal-nhc-text" id="storm-nhc-data-titles" name="storm-nhc-data-titles" value="<%=nhcTrackDataTitles%>"/>
+                                            <br/>
+                                            <label for="storm-nhc-child-param">E-b). Resoruces - Data Links</label>
+                                            <div class="storm-modal-nhc-text-desc">Data Links will match up with the associated Data title defined above. Links should be separated by |. The number of links should be equal to the number of titles defined above.</div>
+                                            <input type="text" class="form-control storm-modal-nhc-text" id="storm-nhc-data-links" name="storm-nhc-data-links" value="<%=nhcTrackDataLinks%>"/>    
+                                        </div>
+                                        <br/>
+                                        <br/>
+                                        <button class="btn" type="button" data-toggle="collapse" data-target="#storm-nhc-resources-pub" aria-expanded="false" aria-controls="storm-nhc-resources-pub">F). Resources - Publications</button>
+                                        <div class="collapse" id="storm-nhc-resources-pub">
+                                            <label for="storm-nhc-child-attr">F-a). Resources - Publication Titles</label>
+                                            <div class="storm-modal-nhc-text-desc">One Publication Resource will be created per title. Titles should be separated by |.</div>
+                                            <input type="text" class="form-control storm-modal-nhc-text" id="storm-nhc-pub-titles" name="storm-nhc-pub-titles" value="<%=nhcTrackPubTitles%>"/>
+                                            <br/>
+                                            <label for="storm-nhc-child-param">F-b). Resources - Publication Links</label>
+                                            <div class="storm-modal-nhc-text-desc">Publication Links will match up with the associated Publication title defined above. Links should be separated by |. The number of links should be equal to the number of titles defined above.</div>
+                                            <input type="text" class="form-control storm-modal-nhc-text" id="storm-nhc-pub-links" name="storm-nhc-pub-links" value="<%=nhcTrackPubLinks%>"/>
+                                        </div>
+                                        <br/>
+                                        <br/>
+                                        <button class="btn" type="button" data-toggle="collapse" data-target="#storm-nhc-resources-res" aria-expanded="false" aria-controls="storm-nhc-resources-res">G). Resources - Resources</button>
+                                        <div class="collapse" id="storm-nhc-resources-res">
+                                            <label for="storm-nhc-child-attr">G-a). Resrouces - Resource Titles</label>
+                                            <div class="storm-modal-nhc-text-desc">One Resource will be created per title. Titles should be separated by |.</div>
+                                            <input type="text" class="form-control storm-modal-nhc-text" id="storm-nhc-res-titles" name="storm-nhc-res-titles" value="<%=nhcTrackResTitles%>"/>
+                                            <br/>
+                                            <label for="storm-nhc-child-param">G-b). Resources - Resource Links</label>
+                                            <div class="storm-modal-nhc-text-desc">Resource Links will match up with the associated Resource title defined above. Links should be separated by |. The number of links should be equal to the number of titles defined above.</div>
+                                            <input type="text" class="form-control storm-modal-nhc-text" id="storm-nhc-res-links" name="storm-nhc-res-links" value="<%=nhcTrackResLinks%>"/>        
+                                        </div>
+                                        <br/>
+                                    </div></small>
+                                </form>
+                            </div>
+                        </div>
+                        <br/>
+                        <div>
+                            <label for="inherit-alias">3. Alias to Use [optional]</label>
+                            <span>If the provided Alias is already in-use by another Item it will be removed from that Item and assigned to the newly created Storm.</span>
+                            <br/>
+                            <input type="text" id="inherit-alias" name="inherit-alias"/>
+                        </div>
+                        <br/>
+                        <div>
+                            <label for="copy-type">4. Copy Existing Summary [optional]</label>
+                            <span>The Summary includes the data from the Titles/Descriptions, Keywords, and Resources (Data, Publications, and Resource entires) sections of the publish item page.</span>
+                            <br/>
+                            <label for="copy-none">None <input type="radio" name="copy-type" id="copy-none" value="none" checked/></label>
+                            <label for="copy-item">From Item <input type="radio" name="copy-type" id="copy-item" value="item"/></label>
+                            <label for="copy-alias">From Alias <input type="radio" name="copy-type" id="copy-alias" value="alias"/></label>
+                            <label for="copy-input"><span></span><input type="text" name="copy-input" hidden/></label>
+                        </div>
                         <br/>
                         <p id="storm-modal-result"></p>
                         <br/>

--- a/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/publish/item/index.jsp
+++ b/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/publish/item/index.jsp
@@ -467,7 +467,14 @@
                                                 <label>
                                                     <input type="checkbox" id="checkbox-isactive"> Is Active?
                                                 </label>
-
+                                                <div>
+                                                    <small>
+                                                        <div id="active-to-inactive-warning">
+                                                            Note: Changing a Storm item from Active to Inactive will automatically delete the NHC Storm Track item nested underneath it (if present).
+                                                        </div>
+                                                        <br/>
+                                                    </small>
+                                                </div>
                                             </div>
                                         </div>
 
@@ -881,6 +888,7 @@
                                             <textarea class="form-control storm-modal-nhc-text" id="storm-nhc-sum-full-text" rows="4" maxlength="64000" name="storm-nhc-sum-full-text"><%=nhcTrackFullText%></textarea>
                                             <br/>
                                             <label for="storm-nhc-sum-keywords">D-f). Summary - Keywords</label>
+                                            <div class="storm-modal-nhc-text-desc">Keywords should be separated by |.</div>
                                             <textarea class="form-control storm-modal-nhc-text" id="storm-nhc-sum-keywords" rows="4" maxlength="64000" name="storm-nhc-sum-keywords"><%=nhcTrackKeywords%></textarea>
                                         </div>
                                         <br/>
@@ -939,6 +947,7 @@
                             <label for="copy-none">None <input type="radio" name="copy-type" id="copy-none" value="none" checked/></label>
                             <label for="copy-item">From Item <input type="radio" name="copy-type" id="copy-item" value="item"/></label>
                             <label for="copy-alias">From Alias <input type="radio" name="copy-type" id="copy-alias" value="alias"/></label>
+                            <br/>
                             <label for="copy-input"><span></span><input type="text" name="copy-input" hidden/></label>
                         </div>
                         <br/>

--- a/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/publish/item/index.jsp
+++ b/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/publish/item/index.jsp
@@ -788,6 +788,74 @@
                             <br/>
                             <div>
                                 <label for="new-active">2. Is Storm Active? <input type="checkbox" id="new-active" name="new-active"/></label>
+                                <span>Only storms marked as being active will contain an NHC Storm Track child item.</span>
+                                <div id="edit-new-track" style="/*! border: 1px solid black; */">
+                                    <br>
+                                    <label>2a).Modify NHC Storm Track</label>
+                                    <div id="storm-modal-nhc-form">
+                                        <small><div id="storm-nhc-bbox" class="">
+                                            <label for="storm-nhc-bbox-table">A). Bounding Box</label>
+                                            <label for="nhc-bbox-inherit">Inherit from Storm Shape File? <input id="nhc-bbox-inherit" name="nhc-bbox-inherit" type="checkbox"></label>
+                                            <table id="storm-nhc-bbox-table">
+                                                <tbody><tr>
+                                                    <td></td>
+                                                    <td id="storm-nhc-bbox-table-north">
+                                                        <label for="storm-nhc-bbox-input-north">North</label>
+                                                        <input id="storm-nhc-bbox-input-north" class="form-control bbox" placeholder="180" type="text">
+                                                    </td>
+                                                    <td></td>
+                                                </tr>
+                                                <tr>
+                                                    <td id="storm-nhc-bbox-table-west">
+                                                        <label for="storm-nhc-bbox-input-west">West</label>
+                                                        <input id="storm-nhc-bbox-input-west" class="form-control bbox" placeholder="-180" type="text">
+                                                    </td>
+                                                    <td></td>
+                                                    <td id="storm-nhc-bbox-table-east">
+                                                        <label for="storm-nhc-bbox-input-east">East</label>
+                                                        <input id="storm-nhc-bbox-input-east" class="form-control bbox" placeholder="180" type="text">
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td></td>
+                                                    <td id="storm-nhc-bbox-table-south">
+                                                        <label for="storm-nhc-bbox-input-south">South</label>
+                                                        <input id="storm-nhc-bbox-input-south" class="form-control bbox" placeholder="-180" type="text">
+                                                    </td>
+                                                    <td></td>
+                                                </tr>
+                                            </tbody></table>
+                                        </div></small>
+                                        <br/>
+                                        <small><div id="storm-nhc-wms" class="">
+                                            <label for="storm-nhc-wms-link">B). WMS URL</label>
+                                            <input type="text" class="form-control storm-modal-nhc-text" id="storm-nhc-wms-link" name="storm-nhc-wms-link"/>
+                                            <br/>
+                                            <label for="storm-nhc-child-attr">C). Child WMS Attributes</label>
+                                            <div class="storm-modal-nhc-text-desc">One child item will be made per specified attribute name. Attributes should be separated by |.</div>
+                                            <input type="text" class="form-control storm-modal-nhc-text" id="storm-nhc-child-attr" name="storm-nhc-child-attr"/>
+                                            <br/>
+                                            <label for="storm-nhc-child-param">D). Child WMS Attribute Parameters</label>
+                                            <div class="storm-modal-nhc-text-desc">The list of WMS parameters to provide for each child attribute. Multiple parameters may be provided per attribute, separated by commas. Attributes should be separated by |. The number of groups here should be equal to the number of attributes specified above.</div>
+                                            <input type="text" class="form-control storm-modal-nhc-text" id="storm-nhc-child-param" name="storm-nhc-child-param"/>
+                                            <br/>
+                                            <label for="storm-nhc-wms-link">E). Summary - Tiny Text</label>
+                                            <textarea class="form-control storm-modal-nhc-text" id="storm-nhc-wms-link" rows="1" maxlength="105" name="storm-nhc-wms-link"></textarea>
+                                            <br/>
+                                            <label for="storm-nhc-wms-link">F). Summary - Medium Title</label>
+                                            <textarea class="form-control storm-modal-nhc-text" id="storm-nhc-wms-link" rows="1" maxlength="1024" name="storm-nhc-wms-link"></textarea>
+                                            <br/>
+                                            <label for="storm-nhc-wms-link">G). Summary - Medium Text</label>
+                                            <textarea class="form-control storm-modal-nhc-text" id="storm-nhc-wms-link" rows="2" maxlength="2048" name="storm-nhc-wms-link"></textarea>
+                                            <br/>
+                                            <label for="storm-nhc-wms-link">H). Summary - Full Title</label>
+                                            <textarea class="form-control storm-modal-nhc-text" id="storm-nhc-wms-link" rows="1" maxlength="1024" name="storm-nhc-wms-link"></textarea>
+                                            <br/>
+                                            <label for="storm-nhc-wms-link">I). Summary - Full Text</label>
+                                            <textarea class="form-control storm-modal-nhc-text" id="storm-nhc-wms-link" rows="3" maxlength="64000" name="storm-nhc-wms-link"></textarea>
+                                        </div></small>
+                                    </div>
+                                </div>
                             </div>
                             <br/>
                             <div>

--- a/coastal-hazards-portal/src/main/webapp/less/publish/publish.less
+++ b/coastal-hazards-portal/src/main/webapp/less/publish/publish.less
@@ -416,6 +416,21 @@ form-publish-info-item-panel-children .panel-body {
     font-style: italic;
 }
 
+#storm-modal-nhc-form {
+	margin-left: 5%;
+	max-width: 95%;
+	max-height: 400px;
+	overflow-y: scroll;
+}
+
+.storm-modal-nhc-text {
+    max-width: 97%;
+}
+
+.storm-modal-nhc-text-desc {
+	margin-bottom: 5px;
+}
+
 @media screen and (min-width:768px){
     
     .flexSection{

--- a/coastal-hazards-portal/src/main/webapp/less/publish/publish.less
+++ b/coastal-hazards-portal/src/main/webapp/less/publish/publish.less
@@ -419,8 +419,6 @@ form-publish-info-item-panel-children .panel-body {
 #storm-modal-nhc-form {
 	margin-left: 5%;
 	max-width: 95%;
-	max-height: 400px;
-	overflow-y: scroll;
 }
 
 .storm-modal-nhc-text {


### PR DESCRIPTION
Note that this will also require context.xml changes on the portal tomcat before it is deployed. I will make those changes on DEV once this PR has been approved.

New context.xml variables for NHC Track default values (all values are optional, missing values will be blank), see `coastal-hazards-portal/docker/context.xml` for the current default values for these variables:

coastal-hazards.nhc.track.bbox.north - Numeric (cast from String)
coastal-hazards.nhc.track.bbox.west - Numeric (cast from String)
coastal-hazards.nhc.track.bbox.east - Numeric (cast from String)
coastal-hazards.nhc.track.bbox.south - Numeric (cast from String)
coastal-hazards.nhc.track.wms - String
coastal-hazards.nhc.track.attrs - String
coastal-hazards.nhc.track.attr.params - String
coastal-hazards.nhc.track.tiny.text - String
coastal-hazards.nhc.track.med.title - String
coastal-hazards.nhc.track.med.text - String
coastal-hazards.nhc.track.full.title - String
coastal-hazards.nhc.track.full.text - String
coastal-hazards.nhc.track.keywords -String
coastal-hazards.nhc.track.data.titles - String
coastal-hazards.nhc.track.data.links - String
coastal-hazards.nhc.track.pub.titles - String
coastal-hazards.nhc.track.pub.links - String
coastal-hazards.nhc.track.res.titles - String
coastal-hazards.nhc.track.res.links - String