### PR TITLE
Automatically Report Test Coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,4 @@ jdk:
 cache:
   directories:
     - $HOME/.m2
+    - $HOME/codacy

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: java
 jdk:
   - oraclejdk8
+
+after_success:
+  - ./reportCoverageToCodacy.sh
+
 cache:
   directories:
     - $HOME/.m2

--- a/reportCoverageToCodacy.sh
+++ b/reportCoverageToCodacy.sh
@@ -1,18 +1,31 @@
+#!/bin/bash
+
+# Report test coverage data to Codacy
+
+#only report coverage if both API token and project token are defined
 if [ -n "$CODACY_API_TOKEN" ]
 then
 	if [ -n "$CODACY_PROJECT_TOKEN" ]
 	then
-		sudo apt-get install jq
 		mkdir -p ~/codacy
+		#if a copy of the code reporter has not already been cached
 		if [ ! -f ~/codacy/coverage-reporter-assembly-latest.jar ]
 		then
+			#install a tool for parsing a REST API response from GitHub
+			sudo apt-get install jq
+			#install the latest release from GitHub
 			wget -O ~/codacy/coverage-reporter-assembly-latest.jar $(curl https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r .assets[0].browser_download_url)
 		fi
+		
+		#find all coverage report files produced during the build, report them to Codacy
+		#the jar implicitly looks for the API and project token env vars
 		find -iname 'jacoco.xml' -exec java -jar ~/codacy/coverage-reporter-assembly-latest.jar report -l Java -r {} --partial \;
+		#now that all partial coverage reports have been uploaded, tell Codacy we are done
 		java -jar ~/codacy/coverage-reporter-assembly-latest.jar final
+		#TODO: Eliminate the need for partial reporting by using the jacoco maven plugin's `report-aggregate` and/or `merge` goals to produce a single coverage report file. At that point it might be easier to use https://github.com/halkeye/codacy-maven-plugin than manually downloading and invoking the jar.
 	else
-		echo "Skipping coverage reporting -- No codacy project token."
+		echo "Skipping coverage reporting -- No Codacy project token."
 	fi
 else
-	echo "Skipping coverage reporting -- No codacy API token."
+	echo "Skipping coverage reporting -- No Codacy API token."
 fi

--- a/reportCoverageToCodacy.sh
+++ b/reportCoverageToCodacy.sh
@@ -1,0 +1,18 @@
+if [ -n "$CODACY_API_TOKEN" ]
+then
+	if [ -n "$CODACY_PROJECT_TOKEN" ]
+	then
+		sudo apt-get install jq
+		mkdir -p ~/codacy
+		if [ ! -f ~/codacy/coverage-reporter-assembly-latest.jar ]
+		then
+			wget -O ~/codacy/coverage-reporter-assembly-latest.jar $(curl https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r .assets[0].browser_download_url)
+		fi
+		find -iname 'jacoco.xml' -exec java -jar ~/codacy/coverage-reporter-assembly-latest.jar report -l Java -r {} --partial \;
+		java -jar ~/codacy/coverage-reporter-assembly-latest.jar final
+	else
+		echo "Skipping coverage reporting -- No codacy project token."
+	fi
+else
+	echo "Skipping coverage reporting -- No codacy API token."
+fi


### PR DESCRIPTION
Due to pom changes in #1631 , there are now HTML, CSV, and XML coverage report files in the `target` directory of each maven submodule. If IDEs support viewing jacoco coverage, they should pick up on the report files after a build and use them to paint our lines of code red, yellow, or green according to their coverage status.

This pull request adds a script that finds all XML coverage reports and uploads them to Codacy. The script only performs the reporting if the appropriate security tokens are present in the environment variables. We associate the security tokens with secret environment variables in the [USGS-CIDA repo's Travis setting page](https://travis-ci.org/USGS-CIDA/coastal-hazards/settings). Secret env vars are not available to pull requests issued from forks because someone could just PR some code that echoes the secrets and then go have a lot of fun with them :grinning:  Secret env vars _are_ available to post-merge builds and to pull requests issued between branches within the canonical (USGS-CIDA) repository.

Since we currently use a fork-and-feature-branch git workflow, we can't take advantage of coverage analysis in pull requests. Would it be cool to try out a feature branch workflow that doesn't use forks to see if the coverage info is helpful at pull request time?