### PR TITLE
Sugar Free CCH

### DIFF
--- a/coastal-hazards-portal/pom.xml
+++ b/coastal-hazards-portal/pom.xml
@@ -218,10 +218,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.webjars</groupId>
-			<artifactId>sugar</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.webjars</groupId>
 			<artifactId>openlayers</artifactId>
 		</dependency>
 		<dependency>

--- a/coastal-hazards-portal/src/main/resources/application.properties
+++ b/coastal-hazards-portal/src/main/resources/application.properties
@@ -1,6 +1,5 @@
 application.version=${pom.version}
 version.jqueryui=${version.jqueryui}
-version.sugarjs=${version.sugarjs}
 version.jquery=${version.jquery}
 version.bootstrap=${version.bootstrap}
 version.fontawesome=${version.fontawesome}

--- a/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/login.jsp
+++ b/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/login.jsp
@@ -27,7 +27,6 @@
 	String vBootstrap = getProp("version.bootstrap");
 	String vFontAwesome = getProp("version.fontawesome");
 	String vOpenlayers = getProp("version.openlayers");
-	String vSugarJs = getProp("version.sugarjs");
 	String vHandlebars = getProp("version.handlebars");
 
 %>

--- a/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/publish/item/index.jsp
+++ b/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/publish/item/index.jsp
@@ -42,7 +42,6 @@
     String vBootstrap = getProp("version.bootstrap");
     String vFontAwesome = getProp("version.fontawesome");
     String vOpenlayers = getProp("version.openlayers");
-    String vSugarJs = getProp("version.sugarjs");
     String vHandlebars = getProp("version.handlebars");
     String baseUrl = props.getProperty("coastal-hazards.base.secure.url");
     baseUrl = StringUtils.isNotBlank(baseUrl) ? baseUrl : request.getContextPath();
@@ -92,7 +91,7 @@
         <script type="text/javascript" src="<%=baseUrl%>/webjars/jquery-ui/<%=vJqueryUI%>/ui/<%= development ? "" : "minified"%>/jquery-ui<%= development ? "" : ".min"%>.js"></script>
         <script type="text/javascript" src="<%=baseUrl%>/webjars/bootstrap/<%=vBootstrap%>/js/bootstrap<%= development ? "" : ".min"%>.js"></script>
         <script type="text/javascript" src="<%=baseUrl%>/webjars/openlayers/<%=vOpenlayers%>/OpenLayers<%= development ? ".debug" : ""%>.js"></script>
-        <script type="text/javascript" src="<%=baseUrl%>/webjars/sugar/<%=vSugarJs%>/sugar-full<%= development ? ".development" : ".min"%>.js"></script>
+
 
         <jsp:include page="../../../../js/third-party/jsuri/jsuri.jsp">
             <jsp:param name="baseUrl" value="<%=baseUrl + '/'%>" /> 

--- a/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/publish/tree/index.jsp
+++ b/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/publish/tree/index.jsp
@@ -99,7 +99,7 @@
 
 
 		<script type="text/javascript">
-			window.CCH = Object.extended();
+			window.CCH = {};
 			CCH.config = {
 				'id': '${it.id}' || 'uber',
 				'baseUrl': '<%=baseUrl%>',

--- a/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/publish/tree/index.jsp
+++ b/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/publish/tree/index.jsp
@@ -25,7 +25,6 @@
 	String vJqueryUI = getProp("version.jqueryui");
 	String vBootstrap = getProp("version.bootstrap");
 	String vFontAwesome = getProp("version.fontawesome");
-	String vSugarJs = getProp("version.sugarjs");
 	String vJsTree = getProp("version.jstree");
 	String vJquery = getProp("version.jquery");
 %>
@@ -97,7 +96,7 @@
 		<script type="text/javascript" src="<%=baseUrl%>/webjars/jquery/<%=vJquery%>/jquery<%= development ? "" : ".min"%>.js"></script>
 		<script type="text/javascript" src="<%=baseUrl%>/webjars/jstree/<%=vJsTree%>/jstree<%= development ? "" : ".min"%>.js"></script>
 		<script type="text/javascript" src="<%=baseUrl%>/webjars/jquery-ui/<%=vJqueryUI%>/ui<%= development ? "" : "/minified"%>/jquery-ui<%= development ? "" : ".min"%>.js"></script>
-		<script type="text/javascript" src="<%=baseUrl%>/webjars/sugar/<%=vSugarJs%>/sugar-full<%= development ? ".development" : ".min"%>.js"></script>
+
 
 		<script type="text/javascript">
 			window.CCH = Object.extended();

--- a/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/ui/back/index-print.jsp
+++ b/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/ui/back/index-print.jsp
@@ -70,7 +70,6 @@
 	String version = props.getProperty("application.version");
 	String resourceSuffix = development ? "" : "-" + version + "-min";
 	String vJquery = getProp("version.jquery");
-	String vSugarJs = getProp("version.sugarjs");
 	String vFontAwesome = getProp("version.fontawesome");
 
 	pageContext.setAttribute("textOnlyClient", isTextOnlyClient(userAgent));
@@ -200,7 +199,7 @@
 			</div>
 		</div>
 		<script type="text/javascript" src="<%=baseUrl%>/webjars/jquery/<%=vJquery%>/jquery<%= development ? "" : ".min"%>.js"></script>
-		<script type="text/javascript" src="<%=baseUrl%>/webjars/sugar/<%=vSugarJs%>/sugar-full<%= development ? ".development" : ".min"%>.js"></script>
+
 		<script type="text/javascript" src="<%=baseUrl%>/js/cch/util/Util<%= resourceSuffix%>.js"></script>
 		<script type="text/javascript">
 			$(document).on('ready', function () {

--- a/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/ui/back/index.jsp
+++ b/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/ui/back/index.jsp
@@ -76,7 +76,6 @@
 	String resourceSuffix = development ? "" : "-" + version + "-min";
 	String vJquery = getProp("version.jquery");
 	String vBootstrap = getProp("version.bootstrap");
-	String vSugarJs = getProp("version.sugarjs");
 	String vJsTree = getProp("version.jstree");
 	String vHandlebars = getProp("version.handlebars");
 	String referer = request.getHeader("referer");
@@ -285,7 +284,7 @@
                 </div>
                 <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>
                 <script type="text/javascript" src="<%=baseUrl%>/webjars/bootstrap/<%=vBootstrap%>/js/bootstrap<%= development ? "" : ".min"%>.js"></script>
-                <script type="text/javascript" src="<%=baseUrl%>/webjars/sugar/<%=vSugarJs%>/sugar-full<%= development ? ".development" : ".min"%>.js"></script>
+
                 <script type="text/javascript">
 			var CCH = {
 				Objects: {},

--- a/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/ui/front/index.jsp
+++ b/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/ui/front/index.jsp
@@ -30,7 +30,6 @@
 	String vBootstrap = getProp("version.bootstrap");
 	String vFontAwesome = getProp("version.fontawesome");
 	String vOpenlayers = getProp("version.openlayers");
-	String vSugarJs = getProp("version.sugarjs");
 	String vHandlebars = getProp("version.handlebars");
 	String vIntroJs = getProp("version.introjs");
 	String resourceSuffix = development ? "" : "-" + version + "-min";
@@ -189,7 +188,7 @@
 		<script type="text/javascript" src="<%=baseUrl%>/js/cch/objects/widget/Legend<%= resourceSuffix %>.js"></script>
 		<script type="text/javascript" src="<%=baseUrl%>/js/application/front/OnInitialized<%= resourceSuffix %>.js"></script>
 		<script type="text/javascript" src="<%=baseUrl%>/js/application/front/OnReady<%= resourceSuffix %>.js"></script>
-		<script type="text/javascript" src="<%=baseUrl%>/webjars/sugar/<%=vSugarJs%>/sugar-full<%= development ? ".development" : ".min"%>.js"></script>
+
 		<script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>
 		<script type="text/javascript" src="<%=baseUrl%>/webjars/intro.js/<%=vIntroJs%>/intro<%= development ? "" : ".min"%>.js"></script>
 		<script type="text/javascript" src="<%=baseUrl%>/js/cch/objects/front/Intro<%= resourceSuffix %>.js"></script>

--- a/coastal-hazards-portal/src/main/webapp/js/application/back/OnReady.js
+++ b/coastal-hazards-portal/src/main/webapp/js/application/back/OnReady.js
@@ -34,7 +34,7 @@ $(document).ready(function () {
 				itemId: item.id,
 				callbacks: {
 					success: [function(data) {
-						data.each(function(alias, index) {
+						data.forEach(function(alias, index) {
 							if(alias.id != null){
 								item.aliases.push(alias.id);
 							}

--- a/coastal-hazards-portal/src/main/webapp/js/application/front/OnInitialized.js
+++ b/coastal-hazards-portal/src/main/webapp/js/application/front/OnInitialized.js
@@ -29,7 +29,7 @@ CCH.CONFIG = CCH.CONFIG || {};
 						// fully hydrated, so I can now add sub items to the accordion and remove the overlay.
 						// I can also now load and attach item aliases
 						if (obj.id === 'uber') {
-							data.children.each(function (id, index) {
+							data.children.forEach(function (id, index) {
 								var item = CCH.items.getById({id: id});
 
 								// Add it to the accordion...
@@ -65,7 +65,7 @@ CCH.CONFIG = CCH.CONFIG || {};
 							CCH.Util.Search().getAllAliases({
 								callbacks: {
 									success: [function(data) {
-										data.each(function(alias, index) {
+										data.forEach(function(alias, index) {
 											if(alias.item_id != null && CCH.items.getById({id: alias.item_id}) != null){
 												CCH.items.getById({id: alias.item_id}).aliases.push(alias.id);
 											}

--- a/coastal-hazards-portal/src/main/webapp/js/application/front/OnInitialized.js
+++ b/coastal-hazards-portal/src/main/webapp/js/application/front/OnInitialized.js
@@ -184,7 +184,7 @@ CCH.CONFIG = CCH.CONFIG || {};
 						} else {
 							// The item could not be found. Show an error and wait for the app to resize
 							// (happens on loading completetion). When it happens, zoom to the bounding
-							// box of the map's initial extent (the continentat US) and then unbind the handler
+							// box of the map's initial extent (the continental US) and then unbind the handler
 							alertify.error('The item you\'re looking for could not be found.', 6000);
 							var resizeHandler = function () {
 								$(window).off('cch.ui.resized', resizeHandler);

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/Bucket.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/Bucket.js
@@ -52,6 +52,7 @@ CCH.Objects.Bucket = function (args) {
 	};
 	me.bucketRemoveClickHandler = function (evt, args) {
 		args = args || {};
+		console.log("Remove handler for " + args.id);
 		var id = args.id,
 			item = id ? CCH.items.getById({id: id}) : args.item;
 
@@ -169,8 +170,8 @@ CCH.Objects.Bucket = function (args) {
 				id = item.id;
 
 				// Take the item out of my personal bucket array
-				me.bucket = me.bucket.filter(function (item) {
-					return item.id !== id;
+				me.bucket = me.bucket.filter(function (itm) {
+					return itm.id !== id;
 				});
 
 				// Remove the item from the slide

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/Bucket.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/Bucket.js
@@ -52,7 +52,6 @@ CCH.Objects.Bucket = function (args) {
 	};
 	me.bucketRemoveClickHandler = function (evt, args) {
 		args = args || {};
-		console.log("Remove handler for " + args.id);
 		var id = args.id,
 			item = id ? CCH.items.getById({id: id}) : args.item;
 

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/Bucket.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/Bucket.js
@@ -169,8 +169,8 @@ CCH.Objects.Bucket = function (args) {
 				id = item.id;
 
 				// Take the item out of my personal bucket array
-				me.bucket.remove(function (item) {
-					return item.id === id;
+				me.bucket = me.bucket.filter(function (item) {
+					return item.id !== id;
 				});
 
 				// Remove the item from the slide
@@ -189,7 +189,7 @@ CCH.Objects.Bucket = function (args) {
 			}
 		},
 		removeAll: function () {
-			me.bucket.each(function (item) {
+			me.bucket.forEach(function (item) {
 				me.remove({
 					item: item
 				});

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/ClickControl.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/ClickControl.js
@@ -46,7 +46,7 @@ CCH.Objects.ClickControl = OpenLayers.Class(OpenLayers.Control, {
 		var markerLayer = CCH.map.getMap().getLayersByName('Markers')[0];
 
 		// Remove the marker on the map since the ajax call is no longer out
-		markerLayer.markers.each(function (marker) {
+		markerLayer.markers.forEach(function (marker) {
 			markerLayer.removeMarker(marker);
 			marker.destroy();
 		});
@@ -74,7 +74,7 @@ CCH.Objects.ClickControl = OpenLayers.Class(OpenLayers.Control, {
 				// If markers exist, remove them
 				var markerLayer = marker.map.getLayersByName('Markers')[0];
 				
-				markerLayer.markers.each(function (marker) {
+				markerLayer.markers.forEach(function (marker) {
 					markerLayer.removeMarker(marker);
 					marker.destroy();
 				});

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/Item.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/Item.js
@@ -87,11 +87,17 @@ CCH.Objects.Item = function (args) {
 			// If I have children, load those as well
 			var setLoaded = function (evt, args) {
 				if (!me.loaded) {
-					var loadedItemIsChild = me.children.findIndex(function (childId) {
-						return childId === args.id;
-					}) !== -1,
-							childItems = [],
-							allLoaded;
+					var loadedItemChildIndex = -1;
+					me.children.some(function (childId, index) {
+						if(childId === args.id) {
+							loadedItemChildIndex = index;
+							return true;
+						}
+					});
+
+					var loadedItemIsChild = loadedItemChildIndex !== -1, 
+						childItems = [],
+						allLoaded;
 					if (loadedItemIsChild) {
 						me.children.forEach(function (childId) {
 							var childItem = CCH.items.getById({id: childId});
@@ -101,9 +107,14 @@ CCH.Objects.Item = function (args) {
 						});
 
 						if (childItems.length === me.children.length) {
-							allLoaded = childItems.findIndex(function (childItem) {
-								return !childItem.loaded;
-							}) === -1;
+							var unloadedIndex = -1;
+							childItems.some(function (childItem, index) {
+								if(!childItem.loaded) {
+									unloadedIndex = index;
+									return true;
+								}
+							});
+							allLoaded = unloadedIndex === -1;
 							if (allLoaded) {
 								me.loaded = true;
 								CCH.LOG.debug('Item.js::init():Item ' + me.id + ' finished initializing.');
@@ -251,8 +262,12 @@ CCH.Objects.Item = function (args) {
 			}
 		} else {
 			if (me.ribboned && me.parent && me.parent.ribboned) {
-				index = me.parent.children.findIndex(function (childId) {
-					return me.id === childId;
+				index = -1;
+				me.parent.children.some(function (childId, indx) {
+					if(me.id === childId) {
+						index = indx;
+						return true;
+					}
 				});
 				index += 1;
 				if (index > layers.length + 1) {
@@ -339,8 +354,12 @@ CCH.Objects.Item = function (args) {
 			layerName = aggregationName + this.id;
 
 			if (me.ribboned && me.parent && me.parent.ribboned) {
-				index = me.parent.children.findIndex(function (childId) {
-					return me.id === childId;
+				index = -1;
+				me.parent.children.some(function (childId, indx) {
+					if(me.id === childId) {
+						index = indx;
+						return true;
+					}
 				});
 				index += 1;
 

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/Item.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/Item.js
@@ -93,7 +93,7 @@ CCH.Objects.Item = function (args) {
 							childItems = [],
 							allLoaded;
 					if (loadedItemIsChild) {
-						me.children.each(function (childId) {
+						me.children.forEach(function (childId) {
 							var childItem = CCH.items.getById({id: childId});
 							if (childItem) {
 								childItems.push(childItem);
@@ -154,7 +154,7 @@ CCH.Objects.Item = function (args) {
 				loadDataToItem(me, null);
 			} else {
 				// The child still needs to be loaded
-				me.children.each(function (child) {
+				me.children.forEach(function (child) {
 					new CCH.Objects.Item({
 						id: child,
 						parent: me
@@ -379,7 +379,7 @@ CCH.Objects.Item = function (args) {
 	};
 
 	me.hideLayer = function () {
-		me.getLayerList().layers.each(function (layerName) {
+		me.getLayerList().layers.forEach(function (layerName) {
 			CCH.map.hideLayersByName(layerName);
 		});
 
@@ -471,14 +471,16 @@ CCH.Objects.Item = function (args) {
 		var children = args.children || [],
 				item = args.item || me,
 				itemChildren = item.children;
-				children.add(item);
+				children.push(item);
 				
 		if (itemChildren.length) {
 			for (var cIdx = 0; cIdx < itemChildren.length; cIdx++) {
 				var child = CCH.items.getById({ id : itemChildren[cIdx] });
-				children.union(me.getChildren({
+				children = children.concat(me.getChildren({
 					children : children,
 					item : child
+				}).filter(function(childItem) {
+					return children.indexOf(childItem) < 0;
 				}));
 			}
 		}

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/Item.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/Item.js
@@ -87,15 +87,9 @@ CCH.Objects.Item = function (args) {
 			// If I have children, load those as well
 			var setLoaded = function (evt, args) {
 				if (!me.loaded) {
-					var loadedItemChildIndex = -1;
-					me.children.some(function (childId, index) {
-						if(childId === args.id) {
-							loadedItemChildIndex = index;
-							return true;
-						}
-					});
-
-					var loadedItemIsChild = loadedItemChildIndex !== -1, 
+					var loadedItemIsChild = me.children.some(function (childId) {
+							return childId === args.id
+						}),
 						childItems = [],
 						allLoaded;
 					if (loadedItemIsChild) {
@@ -107,14 +101,9 @@ CCH.Objects.Item = function (args) {
 						});
 
 						if (childItems.length === me.children.length) {
-							var unloadedIndex = -1;
-							childItems.some(function (childItem, index) {
-								if(!childItem.loaded) {
-									unloadedIndex = index;
-									return true;
-								}
+							var allLoaded =	childItems.every(function (childItem) {
+								return childItem.loaded;
 							});
-							allLoaded = unloadedIndex === -1;
 							if (allLoaded) {
 								me.loaded = true;
 								CCH.LOG.debug('Item.js::init():Item ' + me.id + ' finished initializing.');
@@ -262,18 +251,6 @@ CCH.Objects.Item = function (args) {
 			}
 		} else {
 			if (me.ribboned && me.parent && me.parent.ribboned) {
-				index = -1;
-				me.parent.children.some(function (childId, indx) {
-					if(me.id === childId) {
-						index = indx;
-						return true;
-					}
-				});
-				index += 1;
-				if (index > layers.length + 1) {
-					index = layers.length + 1;
-				}
-
 				if (bboxObject[stringifiedBbox]) {
 					index = bboxObject[stringifiedBbox].length + 1;
 					bboxObject[stringifiedBbox].push(me.id);
@@ -354,19 +331,6 @@ CCH.Objects.Item = function (args) {
 			layerName = aggregationName + this.id;
 
 			if (me.ribboned && me.parent && me.parent.ribboned) {
-				index = -1;
-				me.parent.children.some(function (childId, indx) {
-					if(me.id === childId) {
-						index = indx;
-						return true;
-					}
-				});
-				index += 1;
-
-				if (index > layers.length + 1) {
-					index = layers.length + 1;
-				}
-
 				if (bboxObject[stringifiedBbox]) {
 					index = bboxObject[stringifiedBbox].length + 1;
 					bboxObject[stringifiedBbox].push(me.id);
@@ -498,9 +462,9 @@ CCH.Objects.Item = function (args) {
 				children = children.concat(me.getChildren({
 					children : children,
 					item : child
-				}).filter(function(childItem) {
-					return children.indexOf(childItem) < 0;
-				}));
+				})).filter(function(childItem, index, self) {
+					return index == self.indexOf(childItem);
+				});
 			}
 		}
 		

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/Items.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/Items.js
@@ -73,7 +73,7 @@ CCH.Objects.Items = function (args) {
 		},
 		getByAlias: function (args) {
 			var alias = args.alias;
-			var itemIds = Object.keys(CCH.items.getItems())
+			var itemIds = Object.keys(CCH.items.getItems());
 			
 			for(var i = 0; i < itemIds.length; i++){
 				if(me.items[itemIds[i]].aliases.indexOf(alias) >= 0){

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/LayerIdentifyControl.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/LayerIdentifyControl.js
@@ -364,7 +364,7 @@ return {
 							} else if ('%' === units) {
 								$valueContainer.append(displayPoints[i].toFixed(0));
 							} else {
-								if ((displayPoints[i]).isInteger()) {
+								if (Number.isInteger(displayPoints[i])) {
 									$valueContainer.append(displayPoints[i].toFixed(0));
 								}
 								else {

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/LayerIdentifyControl.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/LayerIdentifyControl.js
@@ -170,7 +170,7 @@ return {
 						layerObject = layer;
 					    }
 					});
-					layetIdParts = layerObject.params.SLD.split('/');
+					var layerIdParts = layerObject.params.SLD.split('/');
 					layerId = layerIdParts[layerIdParts.length-1];
 					layerId = layerId.substr(0, layerId.indexOf('?')).length > 0 ? layerId.substr(0, layerId.indexOf('?')) : layerId;
 					if (featuresByName.hasOwnProperty(layerName)) {
@@ -267,8 +267,8 @@ return {
 					height;
 				
 				if (layerName.indexOf('_r_') !== -1) {
-					layerParts = layerName.split('_');
-					layerPart = layerParts[layerParts.length-1];
+					var layerParts = layerName.split('_'),
+						layerPart = layerParts[layerParts.length-1];
 					ribbonIndex = parseInt(layerPart, 10);
 				}
 
@@ -386,12 +386,12 @@ return {
 
 							$table.append($legendRow);
 							sortedRows = $table.find('tbody > tr').toArray().sort(function (a, b) {
-								var aParts = $(a).attr('id').split('-');
-								var aPart = aParts[aParts.length-1];
-								var aVal = parseInt(aPart, 10);
-								var bParts = $(b).attr('id').split('-');
-								var bPart = bParts[bParts.length-1];
-								var bVal = parseInt(bPart, 10);
+								var aParts = $(a).attr('id').split('-'),
+									aPart = aParts[aParts.length-1],
+									aVal = parseInt(aPart, 10),
+									bParts = $(b).attr('id').split('-'),
+									bPart = bParts[bParts.length-1],
+									bVal = parseInt(bPart, 10);
 
 								if(aVal < bVal) {
 									return -1;

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/LayerIdentifyControl.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/LayerIdentifyControl.js
@@ -94,7 +94,7 @@ return {
 				} else if (splitName.length > 2) {
 					return splitName[0];
 				}
-				return splitName.last();
+				return splitName.slice(-1);
 			};
 
 		$(window).trigger('cch.map.control.layerid.responded');
@@ -170,8 +170,8 @@ return {
 						layerObject = layer;
 					    }
 					});
-					
-					layerId = layerObject.params.SLD.split('/').last();
+					layetIdParts = layerObject.params.SLD.split('/');
+					layerId = layerIdParts[layerIdParts.length-1];
 					layerId = layerId.substr(0, layerId.indexOf('?')).length > 0 ? layerId.substr(0, layerId.indexOf('?')) : layerId;
 					if (featuresByName.hasOwnProperty(layerName)) {
 						features = featuresByName[layerName];
@@ -267,10 +267,12 @@ return {
 					height;
 				
 				if (layerName.indexOf('_r_') !== -1) {
-					ribbonIndex = parseInt(layerName.split('_').last(), 10);
+					layerParts = layerName.split('_');
+					layerPart = layerParts[layerParts.length-1];
+					ribbonIndex = parseInt(layerPart, 10);
 				}
 
-				if (displayPoints.count() === 0) {
+				if (displayPoints.length === 0) {
 					$titleContainer.html(title);
 					// Data unavailable, insert two dashes for color and for value
 					$legendRow.append($titleContainer, $colorContainer.empty().html('--'), $valueContainer.append(naAttrText));
@@ -327,14 +329,14 @@ return {
 				
 				} else {
 					//Limit ribbon data to only creating a row for the first features
-					if(ribbonIndex >= 0 && displayPoints.count() > 0){
+					if(ribbonIndex >= 0 && displayPoints.length > 0){
 						var point = displayPoints[0];
 						displayPoints = new Array();
 						displayPoints.push(point);
 					}
 					
 					//Create rows for each point to be displayed in this table
-					for(i = 0; i < displayPoints.count(); i++){
+					for(i = 0; i < displayPoints.length; i++){
 						//Reset Contents
 						$legendRow = $('<tr>').addClass('legend-row');
 						$titleContainer = $('<td />');
@@ -384,8 +386,12 @@ return {
 
 							$table.append($legendRow);
 							sortedRows = $table.find('tbody > tr').toArray().sort(function (a, b) {
-								var aVal = parseInt($(a).attr('id').split('-').last(), 10);
-								var bVal = parseInt($(b).attr('id').split('-').last(), 10);
+								var aParts = $(a).attr('id').split('-');
+								var aPart = aParts[aParts.length-1];
+								var aVal = parseInt(aPart, 10);
+								var bParts = $(b).attr('id').split('-');
+								var bPart = bParts[bParts.length-1];
+								var bVal = parseInt(bPart, 10);
 
 								if(aVal < bVal) {
 									return -1;
@@ -438,7 +444,7 @@ return {
 								
 				$popupHtml.empty().append($tableContainer);
 								
-				if(displayPoints.count() > 1 || CCH.map.getMap().getZoom() < 12){
+				if(displayPoints.length > 1 || CCH.map.getMap().getZoom() < 12){
 					var $noteContainer = $('<small id="zoomNotice">Zoom in further for more accurate results.</small>').css('color', 'black');
 					$popupHtml.append($noteContainer);
 				}
@@ -506,7 +512,7 @@ return {
 		}
 		
 		if (["TIDERISK", "SLOPERISK", "ERRRISK", "SLRISK", "GEOM", "WAVERISK", "CVIRISK", "AE"].indexOf(item.attr.toUpperCase()) !== -1) {
-			for(var i = 0; i < displayPoints.count(); i++){
+			for(var i = 0; i < displayPoints.length; i++){
 				displayColors.push(sld.bins[Math.ceil(displayPoints[i]) - 1].color);
 
 				var category = sld.bins[Math.ceil(displayPoints[i]) - 1].category;

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/LayerIdentifyControl.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/LayerIdentifyControl.js
@@ -170,7 +170,7 @@ return {
 						layerObject = layer;
 					    }
 					});
-					var layerIdParts = layerObject.params.SLD.split('/');
+					var layerIdParts = layerObject.params.SLD.split("/");
 					layerId = layerIdParts[layerIdParts.length-1];
 					layerId = layerId.substr(0, layerId.indexOf('?')).length > 0 ? layerId.substr(0, layerId.indexOf('?')) : layerId;
 					if (featuresByName.hasOwnProperty(layerName)) {
@@ -414,7 +414,7 @@ return {
 				
 				var tables = $popupHtml.find('table').toArray().sort(function (a,b) {
 					var aVal = parseInt($(a).attr('data-attr'));
-					var bVal = parseInt($(a).attr('data-attr'));
+					var bVal = parseInt($(b).attr('data-attr'));
 					
 					if(aVal < bVal) {
 						return -1;

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/LayerIdentifyControl.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/LayerIdentifyControl.js
@@ -267,8 +267,8 @@ return {
 					height;
 				
 				if (layerName.indexOf('_r_') !== -1) {
-					var layerParts = layerName.split('_'),
-						layerPart = layerParts[layerParts.length-1];
+					var layerParts = layerName.split('_');
+					var	layerPart = layerParts[layerParts.length-1];
 					ribbonIndex = parseInt(layerPart, 10);
 				}
 

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/LayerIdentifyControl.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/LayerIdentifyControl.js
@@ -104,7 +104,7 @@ return {
 		// spot
 		if (features.length) {
 			// Get just the displayed layers on the map 
-			cchLayers = CCH.map.getMap().layers.findAll(function (l) {
+			cchLayers = CCH.map.getMap().layers.filter(function (l) {
 				// Having geoserver as part of the url tells me that it's a
 				// CCH layer and not anything else.
 				// Even though the control itself filters by visible layer, I
@@ -118,7 +118,7 @@ return {
 			// over with a different SLD for each layer. In order to handle
 			// that, I need to make an array for the layer name (item.id) 
 			// to be able to process this going forward
-			cchLayers.each(function (l) {
+			cchLayers.forEach(function (l) {
 				var lName = trimLayerName(l.name);
 
 				if (!layerUrlToId[l.params.LAYERS]) {
@@ -137,9 +137,9 @@ return {
 			// This function could probably be rewritten to use only the evt.features
 			// array and not have to duplicate it over and over if multiple layers
 			// are using the same features
-			features.each(function (feature) {
+			features.forEach(function (feature) {
 				ids = layerUrlToId[feature.gml.featureNSPrefix + ':' + feature.gml.featureType];
-				ids.each(function (id) {
+				ids.forEach(function (id) {
 					featuresByName[id].push(feature.attributes);
 				});
 			});
@@ -297,8 +297,10 @@ return {
 						dates.push(date);
 					}
 
-					// Reverse sort the dates
-					dates = dates.unique().sort(function (a, b) {
+					// Reverse sort and de-dupe the dates
+					dates = dates.filter(function(item, pos) {
+						return dates.indexOf(item) == pos;
+					}).sort(function (a, b) {
 						return b - a;
 					});
 
@@ -328,7 +330,7 @@ return {
 					if(ribbonIndex >= 0 && displayPoints.count() > 0){
 						var point = displayPoints[0];
 						displayPoints = new Array();
-						displayPoints.add(point);
+						displayPoints.push(point);
 					}
 					
 					//Create rows for each point to be displayed in this table
@@ -381,8 +383,17 @@ return {
 							var sortedRows;
 
 							$table.append($legendRow);
-							sortedRows = $table.find('tbody > tr').toArray().sortBy(function (row) {
-								return parseInt($(row).attr('id').split('-').last(), 10);
+							sortedRows = $table.find('tbody > tr').toArray().sort(function (a, b) {
+								var aVal = parseInt($(a).attr('id').split('-').last(), 10);
+								var bVal = parseInt($(b).attr('id').split('-').last(), 10);
+
+								if(aVal < bVal) {
+									return -1;
+								} else if(aVal > bVal) {
+									return 1;
+								} else {
+									return 0;
+								}
 							});
 							$table.empty().append(sortedRows);
 						} else {
@@ -395,10 +406,19 @@ return {
 				CCH.map.getMap().getLayerIndex(CCH.map.getMap().getLayersBy('itemid', layerId)[0]);
 				$popupHtml.append($table);
 				
-				var tables = $popupHtml.find('table').toArray().sortBy(function (tbl) {
-					return parseInt($(tbl).attr('data-attr'));
+				var tables = $popupHtml.find('table').toArray().sort(function (a,b) {
+					var aVal = parseInt($(a).attr('data-attr'));
+					var bVal = parseInt($(a).attr('data-attr'));
+					
+					if(aVal < bVal) {
+						return -1;
+					} else if(aVal > bVal) {
+						return 1;
+					} else {
+						return 0;
+					}
 				});
-				tables.each(function (tbl, ind) {
+				tables.forEach(function (tbl, ind) {
 					var $tbl = $(tbl);
 					if (ind === 0) {
 						if ($tbl.find('thead').length === 0) {
@@ -475,7 +495,7 @@ return {
 				
 				//Don't display the point if it is missing the display column
 				if(!isMissing(pFl)){
-					displayPoints.add(pFl);
+					displayPoints.push(pFl);
 					
 					//If we have added a 3rd value stop trying to add more
 					if(displayPoints.length === 3){
@@ -487,7 +507,7 @@ return {
 		
 		if (["TIDERISK", "SLOPERISK", "ERRRISK", "SLRISK", "GEOM", "WAVERISK", "CVIRISK", "AE"].indexOf(item.attr.toUpperCase()) !== -1) {
 			for(var i = 0; i < displayPoints.count(); i++){
-				displayColors.add(sld.bins[Math.ceil(displayPoints[i]) - 1].color);
+				displayColors.push(sld.bins[Math.ceil(displayPoints[i]) - 1].color);
 
 				var category = sld.bins[Math.ceil(displayPoints[i]) - 1].category;
 				
@@ -495,7 +515,7 @@ return {
 					category += "&nbsp;" + units;
 				}
 				
-				displayCategories.add(category);
+				displayCategories.push(category);
 			}	
 		}
 

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/Session.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/Session.js
@@ -244,12 +244,14 @@ CCH.Objects.Session = function (args) {
 
 	me.getItemIndex = function (item) {
 		var idx = -1;
-		me.session.items.some(function(i, index) {
-			if((i == null && item == null) || (i != null && i.itemId === item.id)) {
-				idx = index;
-				return true;
-			}
-		});
+		if(item != null) {
+			me.session.items.some(function(i, index) {
+					if(i != null && i.itemId === item.id) {
+					idx = index;
+					return true;
+				}
+			});
+		}
 		return idx;
 	};
 

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/Session.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/Session.js
@@ -137,7 +137,7 @@ CCH.Objects.Session = function (args) {
 			data: me.toString(),
 			success: function (json, textStatus, jqXHR) {
 				if (callbacks.success && callbacks.success.length > 0) {
-					callbacks.success.each(function (callback) {
+					callbacks.success.forEach(function (callback) {
 						callback.call(null, json, textStatus, jqXHR);
 					});
 				}
@@ -149,7 +149,7 @@ CCH.Objects.Session = function (args) {
 			},
 			error: function (data, textStatus, jqXHR) {
 				if (callbacks.error && callbacks.error.length > 0) {
-					callbacks.error.each(function (callback) {
+					callbacks.error.forEach(function (callback) {
 						callback.call(null, data, textStatus, jqXHR);
 					});
 				}
@@ -279,7 +279,7 @@ CCH.Objects.Session = function (args) {
 		var index = me.getItemIndex(item);
 
 		if (index !== -1) {
-			me.session.items.removeAt(index);
+			me.session.items.splice(index, 1);
 		}
 
 		me.persistSession();

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/Session.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/Session.js
@@ -243,9 +243,14 @@ CCH.Objects.Session = function (args) {
 	};
 
 	me.getItemIndex = function (item) {
-		return me.session.items.findIndex(function (i) {
-			return i.itemId === item.id;
+		var idx = -1;
+		me.session.items.some(function(i, index) {
+			if((i == null && item == null) || (i != null && i.itemId === item.id)) {
+				idx = index;
+				return true;
+			}
 		});
+		return idx;
 	};
 
 	me.addItem = function (args) {

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/back/Intro.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/back/Intro.js
@@ -64,10 +64,10 @@ CCH.intro = (function () {
 			updateForMobile = function () {
 				CCH.ui.toggleControlCenterVisibility(true);
 				CCH.ui.rotateArrow('down');
-				[0, 1, 2, 3, 4, 5, 6].each(function (e) {
+				[0, 1, 2, 3, 4, 5, 6].forEach(function (e) {
 					steps[e].position = 'bottom';
 				});
-				[7, 8].each(function (e) {
+				[7, 8].forEach(function (e) {
 					steps[e].position = 'top';
 				});
 
@@ -78,9 +78,9 @@ CCH.intro = (function () {
 				
 				// Because a user can get a tutorial going on any item, I need to 
 				// check to figure out if the item has had buttons removed
-				[5,3,2].each(function (e) {
+				[5,3,2].forEach(function (e) {
 					if ($(steps[e].element).hasClass('hidden')) {
-						steps.removeAt(e);
+						steps.splice(e, 1);
 					}
 				});
 			};

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/back/UI.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/back/UI.js
@@ -350,14 +350,15 @@ CCH.Objects.Back.UI = function (args) {
 				if (item.children.length !== 0) {
 					for (var cIdx = 0; cIdx < item.children.length; cIdx++) {
 						var childId = item.children[cIdx];
-						services = services.concat(deepDiveToFindAnyServices(CCH.items.getById({id: childId}), services).filter(function(service) {
-							return services.indexOf(service) < 0;
-						}));
+						services = services.concat(deepDiveToFindAnyServices(CCH.items.getById({id: childId}), services)
+							.filter(function(service, index, self) {
+								return index == self.indexOf(service);
+							}));
 					}
 				}
-				services = services.concat(item.services.filter(function(service) {
-					return services.indexOf(service) < 0;
-				}));
+				services = services.concat(item.services).filter(function(service, index, self) {
+					return index == self.indexOf(service);
+				});
 			}
 			return services;
 		};

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/back/UI.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/back/UI.js
@@ -156,7 +156,7 @@ CCH.Objects.Back.UI = function (args) {
 				if (pubTypeArray.length) {
 					pubTypeListHeader.append(subList);
 					me.$publist.append(pubTypeListHeader);
-					me.item.summary.full.publications[type].each(function (publication) {
+					me.item.summary.full.publications[type].forEach(function (publication) {
 						pubLink = $('<a />').attr({
 							'href': publication.link,
 							'target': 'portal_publication_window'
@@ -326,7 +326,7 @@ CCH.Objects.Back.UI = function (args) {
 						'item_data': {
 							'services': (function (s) {
 								var svcs = [];
-								s.each(function (svc) {
+								s.forEach(function (svc) {
 									svcs.push(svc);
 								});
 								return svcs;
@@ -350,16 +350,20 @@ CCH.Objects.Back.UI = function (args) {
 				if (item.children.length !== 0) {
 					for (var cIdx = 0; cIdx < item.children.length; cIdx++) {
 						var childId = item.children[cIdx];
-						services = services.union(deepDiveToFindAnyServices(CCH.items.getById({id: childId}), services));
+						services = services.concat(deepDiveToFindAnyServices(CCH.items.getById({id: childId}), services).filter(function(service) {
+							return services.indexOf(service) < 0;
+						}));
 					}
 				}
-				services = services.union(item.services);
+				services = services.concat(item.services.filter(function(service) {
+					return services.indexOf(service) < 0;
+				}));
 			}
 			return services;
 		};
 		
 		if (deepDiveToFindAnyServices(CCH.CONFIG.item, []).length === 0) {
-			[this.$mapServicesButton, this.$printFormWrapper, this.$downloadDataButton].each(function ($i) {
+			[this.$mapServicesButton, this.$printFormWrapper, this.$downloadDataButton].forEach(function ($i) {
 				$i.addClass('hidden');
 			});
 		}

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/back/UI.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/back/UI.js
@@ -146,7 +146,7 @@ CCH.Objects.Back.UI = function (args) {
 			me.$publist = $('<ul />').attr('id', 'info-container-publications-list');
 			
 			//Publications list (data, resources, and pubs)
-			Object.keys(me.item.summary.full.publications, function (type) {
+			Object.keys(me.item.summary.full.publications).forEach(function (type) {
 				var pubTypeArray = me.item.summary.full.publications[type],
 						pubTypeListHeader = $('<li />')
 						.addClass('publist-header')

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/front/Intro.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/front/Intro.js
@@ -547,9 +547,14 @@ CCH.intro = (function () {
 			if (startingStep) {
 				if (isNaN(startingStep)) {
 					// Find the index of the step with a given name
-					var idx = steps.findIndex(function (s) {
-						return s.name === startingStep;
+					var idx = -1;
+					steps.some(function(s, index) {
+						if(s.name === startingStep) {
+							idx = index;
+							return true;
+						}
 					});
+					
 					// If the name matches a step, start at that step
 					if (idx !== -1) {
 						var step = steps[idx];

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/front/Intro.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/front/Intro.js
@@ -456,7 +456,7 @@ CCH.intro = (function () {
 			updateForMobile = function () {
 
 				//Removing Steps that don't exist on mobile
-				steps.removeAt(4);
+				steps.splice(4, 1);
 
 				//Changing position of text to fit on mobile
 				steps[0].position = 'bottom';

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/front/Map.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/front/Map.js
@@ -102,7 +102,7 @@ CCH.Objects.Front.Map = function (args) {
 			markerLayer = new OpenLayers.Layer.Markers(me.markerLayerName);
 			me.getMap().addLayer(markerLayer);
 			
-			while (markerLayer !== me.getMap().layers.last()) {
+			while (markerLayer !== me.getMap().layers[me.getMap().layers.length-1]) {
 				me.getMap().raiseLayer(markerLayer, 1);
 			}
 		}

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/front/Map.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/front/Map.js
@@ -174,7 +174,7 @@ CCH.Objects.Front.Map = function (args) {
 	me.hideAllLayers = function () {
 		var hiddenLayerNames = [];
 
-		me.getLayersBy('type', 'cch').each(function (layer) {
+		me.getLayersBy('type', 'cch').forEach(function (layer) {
 			me.hideLayer(layer);
 			hiddenLayerNames.push(layer.name);
 		});
@@ -208,7 +208,7 @@ CCH.Objects.Front.Map = function (args) {
 
 	me.removeAllPopups = function () {
 		if (CCH.map.getMap().popups.length) {
-			CCH.map.getMap().popups.each(function (popup) {
+			CCH.map.getMap().popups.forEach(function (popup) {
 				popup.closeDiv.click();
 			});
 		}
@@ -348,7 +348,7 @@ CCH.Objects.Front.Map = function (args) {
 				}
 			} else {
 				// No pinned cards, zoom to the collective bbox of all cards
-				CCH.cards.getCards().each(function (card) {
+				CCH.cards.getCards().forEach(function (card) {
 					bounds.extend(OpenLayers.Bounds.fromArray(card.bbox).transform(CCH.CONFIG.map.modelProjection, CCH.map.getMap().displayProjection));
 				});
 			}
@@ -431,7 +431,7 @@ CCH.Objects.Front.Map = function (args) {
 		hideLayersByName: function (name) {
 			CCH.LOG.trace('Map.js::hideLayersByName: Trying to hide a layer. Layer name: ' + name);
 			var layers = me.map.getLayersByName(name) || [];
-			layers.each(function (layer) {
+			layers.forEach(function (layer) {
 				me.hideLayer(layer);
 			});
 			return layers;
@@ -513,12 +513,12 @@ CCH.Objects.Front.Map = function (args) {
 				$(body).css(cursor, 'wait');
 			});
 			layer.events.register('loadend', layer, function () {
-				var layers = CCH.map.getMap().layers.findAll(function (l) {
+				var layers = CCH.map.getMap().layers.filter(function (l) {
 					return l.type === 'cch';
 				}),
 					layersStillLoading = 0;
 
-				layers.each(function (l) {
+				layers.forEach(function (l) {
 					layersStillLoading += l.numLoadingTiles;
 				});
 

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/front/UI.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/front/UI.js
@@ -317,7 +317,7 @@ CCH.Objects.Front.UI = function (args) {
 		items = items || [];
 		// Wait for each item in the session to be loaded 
 		// before adding it to the bucket
-		items.each(function (item) {
+		items.forEach(function (item) {
 			var loadedHandler = function (evt, args) {
 				var loadedItemId = args.id,
 					sessionItems = CCH.session.getSession().items,
@@ -336,8 +336,14 @@ CCH.Objects.Front.UI = function (args) {
 					item: itemById,
 					visibility: sessionItem.visible
 				});
-				me.bucket.bucket = me.bucket.getItems().sortBy(function (i) {
-					return i.addAtIndex;
+				me.bucket.bucket = me.bucket.getItems().sort(function (a, b) {
+					if(a.addAtIndex < b.addAtIndex) {
+						return -1;
+					} else if(a.addAtIndex > b.addAtIndex) {
+						return 1;
+					} else {
+						return 0;
+					}
 				});
 				me.bucketSlide.cards = me.bucketSlide.cards.sort(function (card) {
 					return me.bucket.getItemById($(card).data('id')).addAtIndex || -1;
@@ -427,7 +433,7 @@ CCH.Objects.Front.UI = function (args) {
 		}
 
 		// I'm going to build a legend per card
-		cards.each(function (card, index) {
+		cards.forEach(function (card, index) {
 			// Every card in the bucket has an associated id referencing the item it belongs to
 			id = card.data('id');
 			
@@ -454,8 +460,14 @@ CCH.Objects.Front.UI = function (args) {
 							if (Object.keys(bucketLegends).length === this.$container.children().length) {
 								// I am the final card that will be loaded. I need to organize my container to 
 								// be indexed in the same way that the bucket is
-								var sortedLegends = this.$container.find('>div').toArray().sortBy(function ($div) {
-									return parseInt($($div).attr('card-index'));
+								var sortedLegends = this.$container.find('>div').toArray().sort(function (a,b) {
+									if($(a).attr('card-index') < $(b).attr('card-index')) {
+										return -1;
+									} else if($(a).attr('card-index') > $(b).attr('card-index')) {
+										return 1;
+									} else {
+										return 0;
+									}
 								});
 
 								this.$container.empty().append(sortedLegends);

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/front/UI.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/front/UI.js
@@ -343,13 +343,7 @@ CCH.Objects.Front.UI = function (args) {
 					visibility: sessionItem.visible
 				});
 				me.bucket.bucket = me.bucket.getItems().sort(function (a, b) {
-					if(a.addAtIndex < b.addAtIndex) {
-						return -1;
-					} else if(a.addAtIndex > b.addAtIndex) {
-						return 1;
-					} else {
-						return 0;
-					}
+					return a.addAtIndex - b.addAtIndex;
 				});
 				me.bucketSlide.cards = me.bucketSlide.cards.sort(function (card) {
 					return me.bucket.getItemById($(card).data('id')).addAtIndex || -1;
@@ -357,7 +351,7 @@ CCH.Objects.Front.UI = function (args) {
 				me.bucketSlide.rebuild();
 			};
 			$(window).on('cch.item.loaded', function (evt, args) {
-				if (args.id === item.itemId) {
+				if (item !== null && args.id === item.itemId) {
 					$(window).off('cch.item.loaded', loadedHandler);
 					loadedHandler(evt, args);
 				}
@@ -467,13 +461,7 @@ CCH.Objects.Front.UI = function (args) {
 								// I am the final card that will be loaded. I need to organize my container to 
 								// be indexed in the same way that the bucket is
 								var sortedLegends = this.$container.find('>div').toArray().sort(function (a,b) {
-									if($(a).attr('card-index') < $(b).attr('card-index')) {
-										return -1;
-									} else if($(a).attr('card-index') > $(b).attr('card-index')) {
-										return 1;
-									} else {
-										return 0;
-									}
+									return $(a).attr('card-index') - $(b).attr('card-index');
 								});
 
 								this.$container.empty().append(sortedLegends);

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/front/UI.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/front/UI.js
@@ -320,11 +320,17 @@ CCH.Objects.Front.UI = function (args) {
 		items.forEach(function (item) {
 			var loadedHandler = function (evt, args) {
 				var loadedItemId = args.id,
-					sessionItems = CCH.session.getSession().items,
-					addIndex = sessionItems.findIndex(function (i) {
-						return i.itemId === args.id;
-					}),
-					sessionItem = sessionItems[addIndex],
+					sessionItems = CCH.session.getSession().items;
+					
+				var addIndex = -1;
+					sessionItems.some(function(i, index) {
+						if(i.itemId === args.id) {
+							addIndex = index;
+							return true;
+						}
+					});
+
+				var sessionItem = sessionItems[addIndex],
 					itemById = CCH.items.getById({
 						id: loadedItemId
 					});

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/publish/UI.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/publish/UI.js
@@ -170,7 +170,7 @@ CCH.Objects.Publish.UI = function () {
 			$resourcesPanel.find('.form-publish-info-item-panel-button-add')]
 				.concat($('.form-group-keyword input'))
 				.concat($bboxes)
-				.each(function ($item) {
+				.forEach(function ($item) {
 					$item.attr(CCH.CONFIG.strings.disabled, CCH.CONFIG.strings.disabled);
 				});
 
@@ -183,11 +183,11 @@ CCH.Objects.Publish.UI = function () {
 			$proxyWmsServiceParamInput, $metadataSummaryField, $itemType, $name]
 				.concat($('.form-group-keyword input'))
 				.concat($bboxes)
-				.each(function ($item) {
+				.forEach(function ($item) {
 					$item.val('');
 				});
 		
-		[$ribbonableCb, $showChildrenCb, $isActiveStormChecbox, $isFeaturedCB].each(function ($i) {
+		[$ribbonableCb, $showChildrenCb, $isActiveStormChecbox, $isFeaturedCB].forEach(function ($i) {
 			$i.prop(CCH.CONFIG.strings.checked, false);
 		});
 		$editingEnabled = false;
@@ -208,7 +208,7 @@ CCH.Objects.Publish.UI = function () {
 	me.enableNewItemForm = function () {
 		$itemType.val('data');
                 [$servicePanel.find('input, button'), $buttonSave, $buttonDelete]
-                        .each(function ($item) {
+                        .forEach(function ($item) {
                             $item.removeAttr(CCH.CONFIG.strings.disabled);
 			});
 		$editingEnabled = true;
@@ -244,7 +244,7 @@ CCH.Objects.Publish.UI = function () {
 			$publicationsPanel.find('#form-publish-info-item-panel-publications-button-add')]
 				.concat($('.form-group-keyword input'))
 				.concat($bboxes)
-				.each(function ($item) {
+				.forEach(function ($item) {
 					$item.removeAttr(CCH.CONFIG.strings.disabled);
 				});
 		$editingEnabled = true;
@@ -609,25 +609,25 @@ CCH.Objects.Publish.UI = function () {
 		    //PYCSW 1.x Support -- Remove After Server pycsw Upgrades Complete
 		    var cswNodes = responseObject.children;
 		    var tag;
-		    cswNodes[0].children.each(function (node) {
+		    cswNodes[0].children.forEach(function (node) {
 			    tag = node.tag;
 
 			    if (tag === 'idinfo') {
-				    node.children.each(function (childNode) {
+				    node.children.forEach(function (childNode) {
 					    tag = childNode.tag;
 					    switch (tag) {
 					    case 'spdom':
 						    if (childNode.children) {
-							    childNode.children[0].children.each(function (spdom) {
+							    childNode.children[0].children.forEach(function (spdom) {
 								    var direction = spdom.tag.substring(0, spdom.tag.length - 2);
 								    $('#form-publish-item-bbox-input-' + direction).val(spdom.text);
 							    });
 						    }
 						    break;
 					    case 'keywords':
-						    childNode.children.each(function (kwNode) {
+						    childNode.children.forEach(function (kwNode) {
 							    var keywords = kwNode.children;
-							    keywords.splice(1).each(function (kwObject) {
+							    keywords.splice(1).forEach(function (kwObject) {
 								    var keyword = kwObject.text;
 								    me.addKeywordGroup(keyword);
 							    });
@@ -673,7 +673,7 @@ CCH.Objects.Publish.UI = function () {
 	
 	me.parseJsonKeywords = function (keywords) {
 	    if(Array.isArray(keywords)){
-		keywords.each(function(keyword) {
+		keywords.forEach(function(keyword) {
 		    me.addKeywordGroup(keyword);
 		})
 	    } else {
@@ -725,12 +725,12 @@ CCH.Objects.Publish.UI = function () {
 			dataType: 'json',
 			contentType: "application/json; charset=utf-8",
 			success: function (json, textStatus, jqXHR) {
-				callbacks.success.each(function (cb) {
+				callbacks.success.forEach(function (cb) {
 					cb(json, textStatus, jqXHR);
 				});
 			},
 			error: function () {
-				callbacks.error.each(function (cb) {
+				callbacks.error.forEach(function (cb) {
 					cb();
 				});
 			}
@@ -751,14 +751,14 @@ CCH.Objects.Publish.UI = function () {
 			dataType: 'json',
 			success: function (json, textStatus, jqXHR) {
 				if (callbacks.success && callbacks.success.length > 0) {
-					callbacks.success.each(function (callback) {
+					callbacks.success.forEach(function (callback) {
 						callback.call(null, json, textStatus, jqXHR);
 					});
 				}
 			},
 			error: function (xhr, status, error) {
 				if (callbacks.error && callbacks.error.length > 0) {
-					callbacks.error.each(function (callback) {
+					callbacks.error.forEach(function (callback) {
 						callback.call(null, xhr, status, error);
 					});
 				}
@@ -790,7 +790,7 @@ CCH.Objects.Publish.UI = function () {
                 
 		if (featureTypes) {
 			featureTypes = featureTypes[0];
-			featureTypes.properties.each(function (ft) {
+			featureTypes.properties.forEach(function (ft) {
 				ftName = ft.name;
 				ftNameLower = ftName.toLowerCase();
 				if ($.inArray(ftNameLower, ['objectid','shape','shape.len', 'the_geom', 'descriptio','name']) === -1) {
@@ -816,7 +816,7 @@ CCH.Objects.Publish.UI = function () {
 	//Unlocks item type and features panel
 	me.unlockItemTypeFeatures = function () {
 	    [$typeSb, $attributeSelect,$featuresPanel.find('button, input')]
-		.each(function ($item) {
+		.forEach(function ($item) {
 		    $item.removeAttr(CCH.CONFIG.strings.disabled);
 		});
 	};
@@ -824,7 +824,7 @@ CCH.Objects.Publish.UI = function () {
 	//Unlocks Titles, Resources, and Metadata Panels
 	me.unlockTitlesResourcesMetadata = function () {
 	    [$titlesPanel.find('button, textarea'), $resourcesPanel.find('button'), $metaDataPanel.find('button, input')]
-		.each(function ($item) {
+		.forEach(function ($item) {
 		    $item.removeAttr(CCH.CONFIG.strings.disabled);
 		});
 	};
@@ -832,7 +832,7 @@ CCH.Objects.Publish.UI = function () {
 	//Locks Titles, Resources, and Metadata Panels
  	me.lockTitlesResourcesMetadata = function () {
 	    [$titlesPanel.find('button, textarea'), $resourcesPanel.find('button'), $metaDataPanel.find('button, input')]
-                .each(function ($item) {
+                .forEach(function ($item) {
                     $item.prop("disabled", true);
                 });
 	};
@@ -977,7 +977,7 @@ CCH.Objects.Publish.UI = function () {
 			
 			//Uniqueness
 			if(errorString == ""){
-				me.allAliasList.each(function(entry) {
+				me.allAliasList.forEach(function(entry) {
 					if(newAlias.id == entry.id && alias.item_id != entry.item_id){
 						errorString = "There is already an alias using this name.";
 					}
@@ -1252,7 +1252,7 @@ CCH.Objects.Publish.UI = function () {
 				url: CCH.CONFIG.contextPath + '/data/alias/item/' + id,
 				method: "GET",
 				success: function(data){
-					data.each(function(alias) {
+					data.forEach(function(alias) {
 						me.createAliasRow(alias.id);
 					});
 				},
@@ -1304,7 +1304,7 @@ CCH.Objects.Publish.UI = function () {
 						.attr(CCH.CONFIG.strings.disabled, CCH.CONFIG.strings.disabled);
 
 				// Fill out services array
-				item.services.each(function (service) {
+				item.services.forEach(function (service) {
 					services[service.type] = {};
 					services[service.type].endpoint = service.endpoint;
 					services[service.type].serviceParameter = service.serviceParameter;
@@ -1369,7 +1369,7 @@ CCH.Objects.Publish.UI = function () {
 						.concat($bboxes)
 						.concat($keywordGroup.find('input'))
 						.concat($keywordGroup.find('button'))
-						.each(function ($item) {
+						.forEach(function ($item) {
 					$item.removeAttr(CCH.CONFIG.strings.disabled);
 				});
 			
@@ -1384,7 +1384,7 @@ CCH.Objects.Publish.UI = function () {
 			$metadataSummaryField.val(summary.version || 'unknown');
 			
 			// Add keywords
-			keywords.each(function (keyword) {
+			keywords.forEach(function (keyword) {
 				me.addKeywordGroup(keyword);
 			});
 			
@@ -1410,7 +1410,7 @@ CCH.Objects.Publish.UI = function () {
 			// Publications
 			$('.form-publish-info-item-panel-button-add').removeAttr(CCH.CONFIG.strings.disabled, CCH.CONFIG.strings.disabled);
 			Object.keys(item.summary.full.publications, function (type) {
-				item.summary.full.publications[type].each(function (publication) {
+				item.summary.full.publications[type].forEach(function (publication) {
 					me.createPublicationRow(publication.link, publication.title, type);
 				});
 			});
@@ -1471,12 +1471,12 @@ CCH.Objects.Publish.UI = function () {
 			data: JSON.stringify(item),
 			contentType: "application/json; charset=utf-8",
 			success: function (obj) {
-				callbacks.success.each(function (cb) {
+				callbacks.success.forEach(function (cb) {
 					cb(obj);
 				});
 			},
 			error: function (obj) {
-				callbacks.error.each(function (cb) {
+				callbacks.error.forEach(function (cb) {
 					cb(obj);
 				});
 			}
@@ -1500,12 +1500,12 @@ CCH.Objects.Publish.UI = function () {
 			data: JSON.stringify(alias),
 			contentType: "application/json; charset=utf-8",
 			success: function (obj) {
-				callbacks.success.each(function (cb) {
+				callbacks.success.forEach(function (cb) {
 					cb(obj);
 				});
 			},
 			error: function (obj) {
-				callbacks.error.each(function (cb) {
+				callbacks.error.forEach(function (cb) {
 					cb(obj);
 				});
 			}
@@ -1529,14 +1529,14 @@ CCH.Objects.Publish.UI = function () {
 				callbacks: {
 					success: [
 						function (featureDescription) {
-							callbacks.success.each(function (cb) {
+							callbacks.success.forEach(function (cb) {
 								cb(featureDescription);
 							});
 						}
 					],
 					error: [
 						function (error) {
-							callbacks.error.each(function (cb) {
+							callbacks.error.forEach(function (cb) {
 								cb(error);
 							});
 						}
@@ -1782,12 +1782,12 @@ CCH.Objects.Publish.UI = function () {
 						$('.resource-list-container-sortable').empty();
 						$('.form-publish-info-item-panel-button-add').removeAttr(CCH.CONFIG.strings.disabled, CCH.CONFIG.strings.disabled);
 						Object.keys(response.full.publications, function (type) {
-							response.full.publications[type].each(function (publication) {
+							response.full.publications[type].forEach(function (publication) {
 								me.createPublicationRow(publication.link, publication.title, type);
 							});
 						});
                                                 
-						response.keywords.split('|').each(function (keyword) {
+						response.keywords.split('|').forEach(function (keyword) {
 							me.addKeywordGroup(keyword);
 						});
 					}
@@ -1903,7 +1903,7 @@ CCH.Objects.Publish.UI = function () {
 		if (errors.length === 0) {
 			performSave();
 		} else {
-			errors.each(function (error) {
+			errors.forEach(function (error) {
 				$li = $('<li />').html(error);
 				$ul.append($li);
 			});
@@ -2035,7 +2035,7 @@ CCH.Objects.Publish.UI = function () {
 									svcName;
 
 							if (jsonResponse.services) {
-								jsonResponse.services.each(function (svc) {
+								jsonResponse.services.forEach(function (svc) {
 									if (svc.type === 'MapServer') {
 										svcName = svc.name.substring(svc.name.indexOf('/') + 1);
 										$li = $('<li />');
@@ -2121,7 +2121,7 @@ CCH.Objects.Publish.UI = function () {
 					'namespace': namespace,
 					'callbacks': {
 						success: [function () {
-								CCH.ows.servers[serverName].data.wms.capabilities.object.capability.layers.each(function (layer) {
+								CCH.ows.servers[serverName].data.wms.capabilities.object.capability.layers.forEach(function (layer) {
 									$li = $('<li />');
 									$a = $('<a />').attr({
 										'href': '#',
@@ -2156,7 +2156,7 @@ CCH.Objects.Publish.UI = function () {
 					'namespace': namespace,
 					'callbacks': {
 						success: [function () {
-								CCH.ows.servers[serverName].data.wms.capabilities.object.capability.layers.each(function (layer) {
+								CCH.ows.servers[serverName].data.wms.capabilities.object.capability.layers.forEach(function (layer) {
 									$li = $('<li />');
 									$a = $('<a />').attr({
 										'href': '#',
@@ -2190,7 +2190,7 @@ CCH.Objects.Publish.UI = function () {
 			'namespace': 'proxied',
 			'callbacks': {
 				success: [function (args) {
-						args.wfsCapabilities.featureTypeList.featureTypes.each(function (layer) {
+						args.wfsCapabilities.featureTypeList.featureTypes.forEach(function (layer) {
 							$li = $('<li />');
 							$a = $('<a />').attr({
 								'href': '#',
@@ -2253,7 +2253,7 @@ CCH.Objects.Publish.UI = function () {
 			'namespace': 'proxied',
 			'callbacks': {
 				success: [function () {
-						CCH.ows.servers[CCH.CONFIG.strings.cidaGeoserver].data.wms.capabilities.object.capability.layers.each(function (layer) {
+						CCH.ows.servers[CCH.CONFIG.strings.cidaGeoserver].data.wms.capabilities.object.capability.layers.forEach(function (layer) {
 							$li = $('<li />');
 							$a = $('<a />').attr({
 								'href': '#',
@@ -2429,7 +2429,7 @@ CCH.Objects.Publish.UI = function () {
 				url: CCH.CONFIG.contextPath + '/data/alias/item/' + $itemIdInput.val(),
 				method: "GET",
 				success: function(data){
-					data.each(function(alias) {
+					data.forEach(function(alias) {
 						me.createAliasRow(alias.id);
 					});
 				},
@@ -2931,7 +2931,7 @@ CCH.Objects.Publish.UI = function () {
 		
 		$aliasModalList.empty();
 		
-		me.allAliasList.each(function(alias) {
+		me.allAliasList.forEach(function(alias) {
 			var fitName = false, fitItem = false;
 			
 			if($nameFilter.val().trim() == "" || alias.id.toLowerCase().includes($nameFilter.val().trim().toLowerCase())){
@@ -2953,7 +2953,7 @@ CCH.Objects.Publish.UI = function () {
 		var callbacks = args.callbacks;
 		var success = callbacks ? callbacks.success : {};
 		var error = callbacks ? callbacks.error : {};
-		me.templateNames.each(function (templateName) {
+		me.templateNames.forEach(function (templateName) {
 			$.ajax({
 				url: CCH.CONFIG.contextPath + '/resource/template/handlebars/publish/' + templateName + '.html',
 				context: {
@@ -2963,7 +2963,7 @@ CCH.Objects.Publish.UI = function () {
 					CCH.ui.templates[this.templateName] = Handlebars.compile(data);
 					
 					if(success){
-						success.each(function(func) {
+						success.forEach(function(func) {
 							func(data);
 						});
 					}
@@ -2972,7 +2972,7 @@ CCH.Objects.Publish.UI = function () {
 					window.alert('Unable to load resources required for a functional publication page. Please contact CCH admin team.');
 					
 					if(error){
-						error.each(function(func) {
+						error.forEach(function(func) {
 							func(data);
 						});
 					}
@@ -3003,7 +3003,7 @@ CCH.Objects.Publish.UI = function () {
 				me.visibleAliasList = data;
 				$buttonManageAliases.removeAttr(CCH.CONFIG.strings.disabled);
 				$aliasModalList.empty();
-				me.allAliasList.each(function(alias){
+				me.allAliasList.forEach(function(alias){
 					me.createModalAliasRow(alias, false);
 				});
 			},

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/publish/UI.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/publish/UI.js
@@ -579,15 +579,18 @@ CCH.Objects.Publish.UI = function () {
 
 	me.addKeywordGroup = function (keyword) {
 		var keywordExists,
+			keywordCount = 0,
 				$keywordGroupLocal;
 		// Figure out if this keyword would be doubled by adding it
-		keywordExists = $form
-				.find('.form-group-keyword input')
-				.not(':first')
-				.toArray()
-				.count(function (input) {
-					return $(input).val().trim() === keyword.trim();
-				}) > 0;
+		$form.find('.form-group-keyword input')
+			.not(':first')
+			.toArray()
+			.forEach(function (input) {
+				if($(input).val().trim() === keyword.trim()) {
+					keywordCount++;
+				}
+			});
+		keywordExists = keywordCount > 0;
 
 		if (!keywordExists) {
 			$keywordGroupLocal = $keywordGroupClone.clone();
@@ -1409,7 +1412,7 @@ CCH.Objects.Publish.UI = function () {
 
 			// Publications
 			$('.form-publish-info-item-panel-button-add').removeAttr(CCH.CONFIG.strings.disabled, CCH.CONFIG.strings.disabled);
-			Object.keys(item.summary.full.publications, function (type) {
+			Object.keys(item.summary.full.publications).forEach(function (type) {
 				item.summary.full.publications[type].forEach(function (publication) {
 					me.createPublicationRow(publication.link, publication.title, type);
 				});
@@ -1781,7 +1784,7 @@ CCH.Objects.Publish.UI = function () {
 					function (response) {
 						$('.resource-list-container-sortable').empty();
 						$('.form-publish-info-item-panel-button-add').removeAttr(CCH.CONFIG.strings.disabled, CCH.CONFIG.strings.disabled);
-						Object.keys(response.full.publications, function (type) {
+						Object.keys(response.full.publications).forEach(function (type) {
 							response.full.publications[type].forEach(function (publication) {
 								me.createPublicationRow(publication.link, publication.title, type);
 							});
@@ -2277,7 +2280,7 @@ CCH.Objects.Publish.UI = function () {
 	});
 	
 	var getLayerIdFromUrl = function(layerUrl){
-		return layerUrl.from(layerUrl.lastIndexOf('/') + 1);
+		return layerUrl.substring(layerUrl.lastIndexOf('/') + 1);
 	};
 		
 	$vectorModalSubmitButton.on(CCH.CONFIG.strings.click, function(e){

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/publish/UI.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/publish/UI.js
@@ -579,6 +579,7 @@ CCH.Objects.Publish.UI = function () {
 
 	me.addKeywordGroup = function (keyword) {
 		var keywordExists,
+			trimmed = keyword.trim(),
 			keywordCount = 0,
 				$keywordGroupLocal;
 		// Figure out if this keyword would be doubled by adding it
@@ -586,7 +587,7 @@ CCH.Objects.Publish.UI = function () {
 			.not(':first')
 			.toArray()
 			.forEach(function (input) {
-				if($(input).val().trim() === keyword.trim()) {
+				if($(input).val().trim() === trimmed) {
 					keywordCount++;
 				}
 			});

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/publish/tree/UI.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/publish/tree/UI.js
@@ -746,19 +746,19 @@ CCH.Objects.Publish.Tree.UI = function (args) {
 	}
 
 	me.updateRandomIdToOriginalId = function (data) {
-		var dataClone = Object.clone(data, true);
-		Object.keys(dataClone, function (k, v) {
-			var children = v.children.map(function (id) {
+		var dataClone = JSON.parse(JSON.stringify(data));
+		Object.keys(dataClone).forEach(function (key) {
+			var children = dataClone[key].children.map(function (id) {
 				return CCH.ui.getTree().get_node(id).state['original-id'];
 			});
-			dataClone[k] = {
+			dataClone[key] = {
 				children: children,
-				displayedChildren: v.displayedChildren
+				displayedChildren: dataClone[key].displayedChildren
 			};
 
-			if (k !== 'uber') {
-				dataClone[CCH.ui.getTree().get_node(k).state['original-id']] = dataClone[k];
-				delete dataClone[k];
+			if (key !== 'uber') {
+				dataClone[CCH.ui.getTree().get_node(key).state['original-id']] = dataClone[key];
+				delete dataClone[key];
 			}
 
 		});

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/publish/tree/UI.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/publish/tree/UI.js
@@ -6,7 +6,7 @@ CCH.Objects.Publish = CCH.Objects.Publish || {};
 CCH.Objects.Publish.Tree = CCH.Objects.Publish.Tree || {};
 CCH.Objects.Publish.Tree.UI = function (args) {
 	"use strict";
-	var me = Object.extended();
+	var me = {};
 
 	$.extend(me, args);
 
@@ -491,10 +491,14 @@ CCH.Objects.Publish.Tree.UI = function (args) {
 			if (displayed) {
 				node.state.displayed = false;
 				$('#' + selectedId + '_anchor');
-				parent.state.displayedChildren.remove(originalId);
+				parent.state.displayedChildren = parent.state.displayedChildren.filter(function(el) {
+					el !== originalId
+				});
 			} else {
 				node.state.displayed = true;
-				parent.state.displayedChildren = parent.state.displayedChildren.union(originalId);
+				if(!parent.state.displayedChildren.includes(originalId)) {
+					parent.state.displayedChildren.push(originalId);
+				}
 			}
 
 			tree.save_state();
@@ -529,7 +533,7 @@ CCH.Objects.Publish.Tree.UI = function (args) {
 					}
 
 					//Update parents
-					[oldParent, newParent].each(function (itemId) {
+					[oldParent, newParent].forEach(function (itemId) {
 						me.itemUpdated(itemId);
 					});
 				}

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/widget/Accordion.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/widget/Accordion.js
@@ -289,7 +289,7 @@ CCH.Objects.Widget.Accordion = function (args) {
 			// I remove the first index here because the first item is the bellow.
 			// There's a check that's done in the 'pathToItem()' function that does
 			// a similar check for id equality but I just short cut it here
-			path = path.removeAt(0);
+			path = path.splice(0, 1);
 
 			// The action begins by opening a bellow. I check here to see if the 
 			// bellow I want to open is already open. If not, bind openPath() to

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/widget/Accordion.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/widget/Accordion.js
@@ -289,7 +289,7 @@ CCH.Objects.Widget.Accordion = function (args) {
 			// I remove the first index here because the first item is the bellow.
 			// There's a check that's done in the 'pathToItem()' function that does
 			// a similar check for id equality but I just short cut it here
-			path = path.splice(0, 1);
+			path.splice(0, 1);
 
 			// The action begins by opening a bellow. I check here to see if the 
 			// bellow I want to open is already open. If not, bind openPath() to

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/widget/BucketSlide.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/widget/BucketSlide.js
@@ -352,9 +352,14 @@ CCH.Objects.Widget.BucketSlide = function (args) {
 	};
 
 	me.getCardIndex = function (id) {
-		return me.cards.findIndex(function (i) {
-			return i.data('id') === id;
+		var cIndex = -1;
+		me.cards.some(function (i, index) {
+			if(i.data('id') === id) {
+				cIndex = index;
+				return true;
+			}
 		});
+		return cIndex;
 	};
 
 	me.add = function (args) {
@@ -413,7 +418,7 @@ CCH.Objects.Widget.BucketSlide = function (args) {
 				// If this ID appears elsewhere in the card stack, don't remove 
 				// it from the map
 				var numOccurrances = children.filter(function(el) {
-					return children === childId;
+					return el === childId;
 				}).length;
 
 				if (numOccurrances > 1) {
@@ -441,9 +446,13 @@ CCH.Objects.Widget.BucketSlide = function (args) {
 			// the bucket class will actually call this function with a proper
 			// id. It's a long way around removing the item but it does hit 
 			// multiple components
+			var deleteList = [];
 			me.cards.reverse().forEach(function ($card) {
+				deleteList.push($card.data('id'));
+			});
+			deleteList.forEach(function(id) {
 				$(window).trigger('cch.slide.bucket.remove', {
-					id: $card.data('id')
+					id: id
 				});
 			});
 			CCH.session.getSession().items = [];
@@ -589,10 +598,15 @@ CCH.Objects.Widget.BucketSlide = function (args) {
 			$imageContainer = $cardHtml.find('.application-slide-bucket-container-card-image');
 
 		// Test if the layer is currently visible. If not, set view button to off 
-		layerCurrentlyInMap = item.getLayerList().layers.every(function (id) {
+		layerCurrentlyInMap = true;
+		item.getLayerList().layers.some(function (id) {
 			var layerArray = CCH.map.getLayersBy('name', id);
-			return layerArray.length > 0 && layerArray[0].getVisibility();
+			if(!(layerArray.length > 0 && layerArray[0].getVisibility())) {
+				layerCurrentlyInMap = false;
+				return true;
+			}
 		});
+		
 		// This is probably the wrong location to be doing this functionality.
 		if (visibility === true && !layerCurrentlyInMap) {
 			item.showLayer({
@@ -675,9 +689,13 @@ CCH.Objects.Widget.BucketSlide = function (args) {
 				var isAggregation = item.itemType === 'aggregation' || item.itemType === 'template',
 					isLayerInMap = false;
 
-				isLayerInMap = item.getLayerList().layers.every(function (id) {
+				isLayerInMap = true;
+				item.getLayerList().layers.some(function (id) {
 					var layerArray = CCH.map.getLayersBy('name', id);
-					return layerArray.length > 0 && layerArray[0].getVisibility();
+					if(!(layerArray.length > 0 && layerArray[0].getVisibility())) {
+						isLayerInMap = false;
+						return true;
+					}
 				});
 
 				if (isLayerInMap) {

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/widget/BucketSlide.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/widget/BucketSlide.js
@@ -192,7 +192,7 @@ CCH.Objects.Widget.BucketSlide = function (args) {
 			$(me.LABEL_ORDER_CLASS).css('visibility', '');
 		}
 
-		me.cards.each(function ($cardClone) {
+		me.cards.forEach(function ($cardClone) {
 			id = $cardClone.data('id');
 			item = CCH.items.getById({id: id});
 			layerNames = item.getLayerList().layers;
@@ -200,7 +200,7 @@ CCH.Objects.Widget.BucketSlide = function (args) {
 			sortedSessionItems.push(sessionItem);
 			layer = CCH.map.getLayersByName(id);
 
-			layerNames.each(function (layerName) {
+			layerNames.forEach(function (layerName) {
 				layer = CCH.map.getLayersByName(layerName);
 				if (layer.length) {
 					layer = layer[0];
@@ -217,7 +217,7 @@ CCH.Objects.Widget.BucketSlide = function (args) {
 		CCH.session.getSession().items = sortedSessionItems;
 		CCH.session.update();
 
-		layers.reverse().each(function (layer) {
+		layers.reverse().forEach(function (layer) {
 			CCH.map.getMap().setLayerIndex(layer, CCH.map.getMap().layers.length - 1);
 		});
 
@@ -241,13 +241,13 @@ CCH.Objects.Widget.BucketSlide = function (args) {
 			$myCard = me.getCard({id: layer.itemid});
 			if (evtType === 'remove') {
 				setTimeout(function () {
-					[$card, $myCard].each(function (card) {
+					[$card, $myCard].forEach(function (card) {
 						findImage(card).removeClass('fa-eye').addClass('fa-eye-slash');
 					});
 				}, 50);
 			} else if (evtType === 'add') {
 				setTimeout(function () {
-					[$card, $myCard].each(function (card) {
+					[$card, $myCard].forEach(function (card) {
 						findImage(card).removeClass('fa-eye-slash').addClass('fa-eye');
 					});
 				}, 50);
@@ -401,7 +401,7 @@ CCH.Objects.Widget.BucketSlide = function (args) {
 		if (id) {
 			childIdArray = args.children.slice(0);
 			$card = me.getCard({id: id});
-			me.cards.removeAt(me.getCardIndex(id));
+			me.cards.splice(me.getCardIndex(id), 1);
 
 			// I have no children, so I'm just going to remove myself from the map
 			if (childIdArray.length === 0) {
@@ -409,10 +409,14 @@ CCH.Objects.Widget.BucketSlide = function (args) {
 			}
 
 			// Remove all children from the map
-			childIdArray.each(function (childId, i, children) {
+			childIdArray.forEach(function (childId, i, children) {
 				// If this ID appears elsewhere in the card stack, don't remove 
 				// it from the map
-				if (children.findAll(childId).length > 1) {
+				var numOccurrances = children.filter(function(el) {
+					return children === childId;
+				}).length;
+
+				if (numOccurrances > 1) {
 					CCH.map.hideLayersByName(childId);
 				}
 			});
@@ -437,7 +441,7 @@ CCH.Objects.Widget.BucketSlide = function (args) {
 			// the bucket class will actually call this function with a proper
 			// id. It's a long way around removing the item but it does hit 
 			// multiple components
-			me.cards.reverse().each(function ($card) {
+			me.cards.reverse().forEach(function ($card) {
 				$(window).trigger('cch.slide.bucket.remove', {
 					id: $card.data('id')
 				});
@@ -453,7 +457,7 @@ CCH.Objects.Widget.BucketSlide = function (args) {
 		var $container = me.getContainer();
 
 		$container.find('>div:not(:first-child())').remove();
-		me.cards.each(function ($card) {
+		me.cards.forEach(function ($card) {
 			me.append($card);
 		});
 		me.redrawArrows();
@@ -519,7 +523,8 @@ CCH.Objects.Widget.BucketSlide = function (args) {
 			// Make sure I'm not trying to move out of bounds
 			if ((direction === -1 && cardIndex !== 0) ||
 				(direction === 1 && cardIndex !== me.cards.length - 1)) {
-				me.cards.removeAt(cardIndex).splice(cardIndex + direction, 0, card);
+				me.cards.splice(cardIndex, 1);
+				me.cards.splice(cardIndex + direction, 0, card);
 			}
 		}
 		me.rebuild();

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/widget/BucketSlide.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/widget/BucketSlide.js
@@ -353,12 +353,12 @@ CCH.Objects.Widget.BucketSlide = function (args) {
 
 	me.getCardIndex = function (id) {
 		var cIndex = -1;
-		me.cards.some(function (i, index) {
-			if(i.data('id') === id) {
-				cIndex = index;
-				return true;
+		for(var i = 0; i < cards.length; i++) {
+			if(cards[i].data('id') === id) {
+				cIndex = i;
+				break;
 			}
-		});
+		}
 		return cIndex;
 	};
 
@@ -446,9 +446,8 @@ CCH.Objects.Widget.BucketSlide = function (args) {
 			// the bucket class will actually call this function with a proper
 			// id. It's a long way around removing the item but it does hit 
 			// multiple components
-			var deleteList = [];
-			me.cards.reverse().forEach(function ($card) {
-				deleteList.push($card.data('id'));
+			var deleteList = me.cards.reverse().map(function(card) {
+				return card.data('id');
 			});
 			deleteList.forEach(function(id) {
 				$(window).trigger('cch.slide.bucket.remove', {
@@ -598,11 +597,9 @@ CCH.Objects.Widget.BucketSlide = function (args) {
 			$imageContainer = $cardHtml.find('.application-slide-bucket-container-card-image');
 
 		// Test if the layer is currently visible. If not, set view button to off 
-		layerCurrentlyInMap = true;
-		item.getLayerList().layers.some(function (id) {
+		layerCurrentlyInMap = !item.getLayerList().layers.some(function (id) {
 			var layerArray = CCH.map.getLayersBy('name', id);
 			if(!(layerArray.length > 0 && layerArray[0].getVisibility())) {
-				layerCurrentlyInMap = false;
 				return true;
 			}
 		});

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/widget/Card.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/widget/Card.js
@@ -337,7 +337,7 @@ CCH.Objects.Widget.Card = function (args) {
 					return $listItem;
 				};
 
-		me.children.each(function (child) {
+		me.children.forEach(function (child) {
 			if (typeof child === 'string') {
 				item = CCH.items.getById({
 					id: child

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/widget/CombinedSearchbar.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/widget/CombinedSearchbar.js
@@ -369,7 +369,8 @@ CCH.Objects.Widget.CombinedSearch = function (args) {
 				parentListEl = target.parentElement,
 				allItems = $('.' + me.DD_TOGGLE_MENU_ITEMS_CLASS),
 				// The id has the type as the last word
-				type = evt.target.id.split('-').last(),
+				typeParts = evt.target.id.split('-'),
+				type = typeParts[typeParts.length-1],
 				isDisabled = $(target).parent().hasClass('disabled');
 
 		ga('send', 'event', {

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/widget/CombinedSearchbar.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/widget/CombinedSearchbar.js
@@ -67,8 +67,9 @@ CCH.Objects.Widget.CombinedSearch = function (args) {
 			// Get all visible, non-modal children of the parent that are also not my container
 			$parentContainerVisibleItems = $parentContainer.find('> :not(:nth-child(3)):not(.hide):not(*[aria-hidden="true"])');
 			// Get the width of child containers
-			childrenCombinedWidth = $parentContainerVisibleItems.toArray().sum(function (el) {
-				return $(el).outerWidth(true);
+			childrenCombinedWidth = 0;
+			$parentContainerVisibleItems.toArray().forEach(function(el) {
+				childrenCombinedWidth += $(el).outerWidth(true);
 			});
 			containerMarginRight = 15; // TODO- This is problematic between IE9 and others
 			idealInputWidth = parentContainerWidth - childrenCombinedWidth - containerMarginRight;

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/widget/Legend.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/widget/Legend.js
@@ -799,8 +799,11 @@ CCH.Objects.Widget.Legend = function (args) {
 			hashKey,
 			tableIndex,
 			lIdx,
-			indexCompare = function (t) {
-				return $(t).attr('legend-index') === currentLegend.attr('legend-index');
+			indexCompare = function (t, index) {
+				if($(t).attr('legend-index') === currentLegend.attr('legend-index')) {
+					tableIndex = index;
+					return true;
+				}
 			};
 
 		// All legend tables have been attained so now I need to actually slice and dice the collection of tables into
@@ -857,7 +860,7 @@ CCH.Objects.Widget.Legend = function (args) {
 									.html(currentLegendCaptionText), $('<br />'));
 						}
 
-						tableIndex = legendTables.findIndex(indexCompare);
+						legendTables.some(indexCompare);
 
 						// I only want to display the first table in this group, so don't kill the first table
 						if (lIdx !== 0) {

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/widget/Legend.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/widget/Legend.js
@@ -824,7 +824,7 @@ CCH.Objects.Widget.Legend = function (args) {
 			legendGroups = {};
 			legendTables.forEach(function(lt) {
 				var group = $(lt).find('tbody').html().hashCode();
-				legendGroups.group === undefined ? legendGroups.group = [lt] : legendGroups.group.push(lt);
+				legendGroups[group] === undefined ? legendGroups[group] = [lt] : legendGroups.group.push(lt);
 			});
 
 			for (hashKey in legendGroups) {

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/widget/OLDrawBoxControl.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/widget/OLDrawBoxControl.js
@@ -32,7 +32,7 @@
 				
 			if (items) {
 				items.forEach(function (i) {
-					CCH.ui.bucket.add({item: i});
+					CCH.ui.bucket.push({item: i});
 				}); 
 			}
 		}

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/widget/SearchSlide.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/widget/SearchSlide.js
@@ -69,7 +69,7 @@ CCH.Objects.Widget.SearchSlide = function (args) {
 		var $locationSlide = $('#' + me.LOCATION_SLIDE_SEARCH_CONTAINER_ID),
 				$productSlide = $('#' + me.PRODUCT_SLIDE_SEARCH_CONTAINER_ID);
 
-		[$locationSlide, $productSlide].each(function ($slide, ind) {
+		[$locationSlide, $productSlide].forEach(function ($slide, ind) {
 			$slide.find('>div:nth-child(1)').empty();
 			$slide.find('>div:nth-child(' + (ind + 2) + ')')
 				.empty()

--- a/coastal-hazards-portal/src/main/webapp/js/cch/util/OWS.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/util/OWS.js
@@ -170,11 +170,11 @@ CCH.Util.OWS = function () {
 					var trimmedResponse = response.responseText.trim();
 					if (trimmedResponse.indexOf('ExceptionText') !== -1) {
 						var errorText = $(trimmedResponse).find('ows\\:ExceptionText');
-						callbacks.error.each(function (cb) {
+						callbacks.error.forEach(function (cb) {
 							cb(errorText.text());
 						});
 					} else {
-						callbacks.success.each(function (cb) {
+						callbacks.success.forEach(function (cb) {
 							cb(trimmedResponse);
 						});
 					}
@@ -198,11 +198,11 @@ CCH.Util.OWS = function () {
 					var trimmedResponse = response.responseText.trim();
 					if (trimmedResponse.indexOf('ExceptionText') !== -1) {
 						var errorText = $(trimmedResponse).find('ows\\:ExceptionText');
-						callbacks.error.each(function (cb) {
+						callbacks.error.forEach(function (cb) {
 							cb(errorText.text());
 						});
 					} else {
-						callbacks.success.each(function (cb) {
+						callbacks.success.forEach(function (cb) {
 							cb(response);
 						});
 					}
@@ -253,7 +253,7 @@ CCH.Util.OWS = function () {
 
 			if ((server === 'dsas-geoserver' || server === 'cida-geoserver') && namespace !== 'ows') {
 				url = CCH.CONFIG.contextPath + me.servers[server].endpoints.wfsGetCapsUrl;
-				url = url.add(namespace + '/', url.indexOf('ows'));
+				url = url.substr(0, url.indexOf('ows')) + namespace + '/' + url.substr(url.indexOf('ows'));
 			} else if (server === 'stpete-arcserver') {
 				url = CCH.CONFIG.contextPath + me.servers[server].endpoints.proxy + '/services/' + namespace + '/MapServer/WFSServer?service=wfs&version=1.1.0&request=GetCapabilities';
 			} else if (server === 'marine-arcserver') {
@@ -266,14 +266,14 @@ CCH.Util.OWS = function () {
 				success: function (data, textStatus, jqXHR) {
 					var response = new OpenLayers.Format.WFSCapabilities.v1_1_0().read(data);
 
-					response.featureTypeList.featureTypes.each(function (ft) {
+					response.featureTypeList.featureTypes.forEach(function (ft) {
 						ft.prefix = namespace;
 					});
 
 					me.servers[server].data.wfs.capabilities.object = response;
 					me.servers[server].data.wfs.capabilities.xml = data;
 
-					sucessCallbacks.each(function (callback) {
+					sucessCallbacks.forEach(function (callback) {
 						callback({
 							wfsCapabilities: response,
 							data: data,
@@ -320,13 +320,13 @@ CCH.Util.OWS = function () {
 					var response = new OpenLayers.Format.WMSCapabilities.v1_3_0().read(data);
 
 					// Fixes an issue with prefixes not being parsed correctly from response
-					response.capability.layers.each(function (n, i) {
+					response.capability.layers.forEach(function (n, i) {
 						n.prefix = namespace;
 					});
 					me.servers[server].data.wms.capabilities.object = response;
 					me.servers[server].data.wms.capabilities.xml = data;
 
-					sucessCallbacks.each(function (callback) {
+					sucessCallbacks.forEach(function (callback) {
 						callback({
 							wmsCapabilities: response,
 							data: data,
@@ -371,7 +371,7 @@ CCH.Util.OWS = function () {
 
 					CCH.LOG.debug('OWS.js::getFilteredFeature: WFS GetFeature parsed .');
 					if (!me.featureTypeDescription[layerPrefix]) {
-						me.featureTypeDescription[layerPrefix] = Object.extended();
+						me.featureTypeDescription[layerPrefix] = {};
 					}
 					me.featureTypeDescription[layerPrefix][layerTitle] = getFeatureResponse;
 
@@ -430,11 +430,11 @@ CCH.Util.OWS = function () {
 				success: function (response) {
 					var responseText = response.responseText;
 					if (responseText.charAt(0) === '{') {
-						callbacks.success.each(function (cb) {
+						callbacks.success.forEach(function (cb) {
 							cb(JSON.parse(responseText));
 						});
 					} else {
-						callbacks.error.each(function (cb) {
+						callbacks.error.forEach(function (cb) {
 							cb(responseText);
 						});
 					}
@@ -489,12 +489,12 @@ CCH.Util.OWS = function () {
 					'outputFormat': 'application/json'
 				},
 				success: function (response) {
-					callbacks.success.each(function (cb) {
+					callbacks.success.forEach(function (cb) {
 						cb(response);
 					});
 				},
 				error: function (response) {
-					callbacks.error.each(function (cb) {
+					callbacks.error.forEach(function (cb) {
 						cb(response);
 					});
 				}

--- a/coastal-hazards-portal/src/main/webapp/js/cch/util/Search.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/util/Search.js
@@ -49,7 +49,7 @@ CCH.Util.Search = function (args) {
 			contentType: 'application/json',
 			dataType: 'jsonp',
 			success: function (data, statusText, xhrResponse) {
-				callbacks.success.each(function (cb) {
+				callbacks.success.forEach(function (cb) {
 					cb.apply(this, [data, statusText, xhrResponse]);
 				});
 				ga('send', 'event', {
@@ -59,7 +59,7 @@ CCH.Util.Search = function (args) {
 				});
 			},
 			error: function (xhr, status, error) {
-				callbacks.error.each(function (cb) {
+				callbacks.error.forEach(function (cb) {
 					cb.apply(this, [xhr, status, error]);
 				});
 				ga('send', 'exception', {
@@ -102,12 +102,12 @@ CCH.Util.Search = function (args) {
 			context: this,
 			traditional: true,
 			success: function (data, statusText, xhrResponse) {
-				callbacks.success.each(function (cb) {
+				callbacks.success.forEach(function (cb) {
 					cb.apply(this, [data, statusText, xhrResponse]);
 				});
 			},
 			error: function (xhr, status, error) {
-				callbacks.error.each(function (cb) {
+				callbacks.error.forEach(function (cb) {
 					cb.apply(this, [xhr, status, error]);
 				});
 			}
@@ -133,12 +133,12 @@ CCH.Util.Search = function (args) {
 			context: this,
 			traditional: true,
 			success: function (data, statusText, xhrResponse) {
-				callbacks.success.each(function (cb) {
+				callbacks.success.forEach(function (cb) {
 					cb.apply(this, [data, statusText, xhrResponse]);
 				});
 			},
 			error: function (xhr, status, error) {
-				callbacks.error.each(function (cb) {
+				callbacks.error.forEach(function (cb) {
 					cb.apply(this, [xhr, status, error]);
 				});
 			}
@@ -159,12 +159,12 @@ CCH.Util.Search = function (args) {
 			context: this,
 			traditional: true,
 			success: function (data, statusText, xhrResponse) {
-				callbacks.success.each(function (cb) {
+				callbacks.success.forEach(function (cb) {
 					cb.apply(this, [data, statusText, xhrResponse]);
 				});
 			},
 			error: function (xhr, status, error) {
-				callbacks.error.each(function (cb) {
+				callbacks.error.forEach(function (cb) {
 					cb.apply(this, [xhr, status, error]);
 				});
 			}
@@ -222,12 +222,12 @@ CCH.Util.Search = function (args) {
 			context: scope,
 			traditional: true,
 			success: function (data, statusText, xhrResponse) {
-				callbacks.success.each(function (cb) {
+				callbacks.success.forEach(function (cb) {
 					cb.apply(this, [data, statusText, xhrResponse]);
 				});
 			},
 			error: function (xhr, status, error) {
-				callbacks.error.each(function (cb) {
+				callbacks.error.forEach(function (cb) {
 					cb.apply(this, [xhr, status, error]);
 				});
 			}

--- a/coastal-hazards-portal/src/main/webapp/js/cch/util/Util.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/util/Util.js
@@ -59,12 +59,12 @@ CCH.Util.Util = {
 		    },
 		    dataType: 'json',
 		    success: function (data, status, jqXHR) {
-			    args.callbacks.success.each(function (cb) {
+			    args.callbacks.success.forEach(function (cb) {
 				    cb.apply(args.context, [data, status, jqXHR]);
 			    });
 		    },
 		    error: function (jqXHR, textStatus, errorThrown) {
-			    args.callbacks.error.each(function (cb) {
+			    args.callbacks.error.forEach(function (cb) {
 				    cb.apply(args.context, [jqXHR, textStatus, errorThrown]);
 			    });
 		    }

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,6 @@
 		<war.dir>src/main/webapp</war.dir>
 		<build.scm.version>${buildNumber}</build.scm.version>
 		<slf4j.version>1.7.13</slf4j.version>
-		<version.sugarjs>1.4.1</version.sugarjs>
 		<version.jquery>2.1.1</version.jquery>
 		<version.jquery.ui>1.11.1</version.jquery.ui>
 		<version.bootstrap>3.3.4</version.bootstrap>
@@ -384,11 +383,6 @@
 				<groupId>org.webjars</groupId>
 				<artifactId>jquery</artifactId>
 				<version>${version.jquery}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.webjars</groupId>
-				<artifactId>sugar</artifactId>
-				<version>${version.sugarjs}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.webjars</groupId>


### PR DESCRIPTION
- Removed SugarJS: It was pretty heavily used however many of the features we were using have since been added (or had equivalent functionality added) to base JavaScript and after going through:  https://github.com/andrewplummer/sugar-object/blob/master/CAUTION.md it looked like upgrading would be just about as much work as just ripping it out.


Due to the way things in Sugar extended base objects and in some cases overloaded the names of base JS functions it was very difficult to find everything so I'm not absolute sure at this point that I've found all of the pieces that need to get ripped out, but at this point I'm at least not seeing any errors and I'm getting the behavior I expect (at least in everything I've tested so far).

Some things are made even more difficult because the behavior can vary based on the underlying object being operated upon. For example, both jQuery and SugarJS add a `.last()` method for objects. jQuery's works only on jQuery objects, and Sugar's works on Arrays. In some cases we didn't follow consistent naming conventions and where most jQuery variables are named with a `$` in front, some weren't so I replaced their `.last()` call with `.slice(-1)` when I shouldn't have. I think I've corrected those, but it's possible there are still others I've missed.

I'm going to continue mucking around in this a bit more between Sprint 0 meetings but I wanted to get it up for review early because it's starting to sprawl a bit.