### PR TITLE
Change travis to use openjdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ services:
   - docker
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 sudo: required
 


### PR DESCRIPTION
last week, Bill and I noticed travis was failing the builds and it appears as though it's because we were using oraclejdk8, so i switched it to openjdk8