### PR TITLE
Changed binning of UVVR(VIC) polygon data, updated file names from EVIC to UVVR in files to reflect new naming

### DIFF
--- a/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/Attributes.java
+++ b/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/Attributes.java
@@ -103,7 +103,7 @@ public class Attributes {
 	public static final String NHC_TRACK_PT_72CAT = "NHC_TRACK_PT_72CAT";
 	public static final String NHC_TRACK_PT_120CAT = "NHC_TRACK_PT_120CAT";
         
-        public static final String VIC = "VIC"; //vulnerability index
+        public static final String UVVR = "UVVR"; //vulnerability index
 	
 	public static final String TCT = "TCT";
 	public static final String TC2 = "TC2";
@@ -213,7 +213,7 @@ public class Attributes {
         
         public static Set<String> getPolygonAttrs() {
 		Set<String> polys = new HashSet<>();
-		polys.add(VIC);
+		polys.add(UVVR);
 		return polys;
 	}
 }

--- a/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/sld/SLDGenerator.java
+++ b/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/sld/SLDGenerator.java
@@ -55,7 +55,7 @@ public class SLDGenerator {
                 sideEffectMapPut(vulnerability, RasterPAE.rasterConfig); //raster pae -probability
                 sideEffectMapPut(vulnerability, RasterCR.rasterConfig); //raster cr - coastal response
                 sideEffectMapPut(vulnerability, OldSchoolOverallCVI.overallOldSchool);
-                sideEffectMapPut(vulnerability, Evic.evic);
+                sideEffectMapPut(vulnerability, UVVR.uvvr);
 		gmap.put(Item.Type.vulnerability, vulnerability);
 		
 		Map<String, SLDConfig> historical = new HashMap<>();

--- a/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/sld/SLDGenerator.java
+++ b/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/sld/SLDGenerator.java
@@ -55,7 +55,7 @@ public class SLDGenerator {
                 sideEffectMapPut(vulnerability, RasterPAE.rasterConfig); //raster pae -probability
                 sideEffectMapPut(vulnerability, RasterCR.rasterConfig); //raster cr - coastal response
                 sideEffectMapPut(vulnerability, OldSchoolOverallCVI.overallOldSchool);
-                sideEffectMapPut(vulnerability, UVVR.uvvr);
+                sideEffectMapPut(vulnerability, Uvvr.uvvr);
 		gmap.put(Item.Type.vulnerability, vulnerability);
 		
 		Map<String, SLDConfig> historical = new HashMap<>();

--- a/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/sld/UVVR.java
+++ b/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/sld/UVVR.java
@@ -10,7 +10,7 @@ import java.util.Map;
  *
  * @author Kathryn Schoephoester <kmschoep@usgs.gov>
  */
-public final class UVVR {
+public final class Uvvr {
 
 	protected static final String[] attrs = new String[]{UVVR};
 	protected static final float[] thresholds = new float[]{-1f, -1f, 0.025f, 0.050f, 0.075f, 0.100f, 0.200f, 0.300f, 0.400f, 0.500f, 0.75f, 1.0f, 1.25f, 1.5f, 1.75f, 2.0f, 999999999f};

--- a/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/sld/UVVR.java
+++ b/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/sld/UVVR.java
@@ -14,7 +14,7 @@ public final class UVVR {
 
 	protected static final String[] attrs = new String[]{UVVR};
 	protected static final float[] thresholds = new float[]{-1f, -1f, 0.025f, 0.050f, 0.075f, 0.100f, 0.200f, 0.300f, 0.400f, 0.500f, 0.75f, 1.0f, 1.25f, 1.5f, 1.75f, 2.0f, 999999999f};
-	protected static final String[] colors = {"#A80000","#2B41FF", "#386DFF", "#3B9DFF","#30CFFF",  "#00FFFF","#70FFD2","#A1FFA4", "#C7FF78", "#E7FF4A","#FFFF00",  "#FFD500", "#FFA600", "#FF7B00","#FF4D00",  "#FF0000"};
+	protected static final String[] colors = {"#A80000", "#2B41FF", "#386DFF", "#3B9DFF", "#30CFFF", "#00FFFF", "#70FFD2", "#A1FFA4", "#C7FF78", "#E7FF4A", "#FFFF00", "#FFD500", "#FFA600", "#FF7B00", "#FF4D00", "#FF0000"};
 
 	protected static final String jspPath = "/SLD/bins_polygon.jsp";
 	protected static final String units = "Vulnerability Index";

--- a/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/sld/UVVR.java
+++ b/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/sld/UVVR.java
@@ -10,11 +10,11 @@ import java.util.Map;
  *
  * @author Kathryn Schoephoester <kmschoep@usgs.gov>
  */
-public final class Evic {
+public final class UVVR {
 
-	protected static final String[] attrs = new String[]{VIC};
-	protected static final float[] thresholds = new float[]{0.0f, 0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f, 0.9f, 1.0f};
-	protected static final String[] colors = {"#2A29E6", "#3F67EB", "#50A7CC", "#07FFE0", "#96FBB7", "#D8F784", "#F3FE09", "#FAAF25", "#F76C12", "#E30B19"};
+	protected static final String[] attrs = new String[]{UVVR};
+	protected static final float[] thresholds = new float[]{-1f, -1f, 0.025f, 0.050f, 0.075f, 0.100f, 0.200f, 0.300f, 0.400f, 0.500f, 0.75f, 1.0f, 1.25f, 1.5f, 1.75f, 2.0f, 999999999f};
+	protected static final String[] colors = {"#A80000","#2B41FF", "#386DFF", "#3B9DFF","#30CFFF",  "#00FFFF","#70FFD2","#A1FFA4", "#C7FF78", "#E7FF4A","#FFFF00",  "#FFD500", "#FFA600", "#FF7B00","#FF4D00",  "#FF0000"};
 
 	protected static final String jspPath = "/SLD/bins_polygon.jsp";
 	protected static final String units = "Vulnerability Index";
@@ -35,7 +35,7 @@ public final class Evic {
 		bins = binsResult;
 	}
 
-	public static final SLDConfig evic = new SLDConfig(
+	public static final SLDConfig uvvr = new SLDConfig(
 			jspPath, units, SLDGenerator.style, SLDGenerator.STROKE_WIDTH_DEFAULT, attrs, thresholds, colors, bins
 	);
 }


### PR DESCRIPTION
Changed UVVR/VIC data to 16 bins instead of the original 10 in sld generation.
Changed file and class names to reflect name change from VIC to UVVR.