### PR TITLE
Replaced URL minifier PathParam with a QueryParam that is URIEncoded …

### DIFF
--- a/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/rest/data/MinifyResource.java
+++ b/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/rest/data/MinifyResource.java
@@ -8,6 +8,7 @@ import gov.usgs.cida.coastalhazards.rest.data.util.HttpUtil;
 import gov.usgs.cida.utilities.gov.usa.go.GoUsaGovUtils;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.net.URLDecoder;
 import java.util.HashMap;
 import java.util.Map;
@@ -41,10 +42,10 @@ public class MinifyResource {
 		Response response;
 		try {
 			if (StringUtils.isNotBlank(url)) {
-				url = URLDecoder.decode(url, "UTF-8");
+				url = URLDecoder.decode(url, StandardCharsets.UTF_8.displayName());
                 TinyGov tinygov = urlManager.load(url);
                 if (tinygov == null) {
-                    String encodedUrl = URLEncoder.encode(url, "UTF-8");
+                    String encodedUrl = URLEncoder.encode(url, StandardCharsets.UTF_8.displayName());
                     String minified = GoUsaGovUtils.minify(encodedUrl);
                     String short_http_url = GoUsaGovUtils.getUrlFromResponse(minified);
                     if (short_http_url == null) {

--- a/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/rest/data/MinifyResource.java
+++ b/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/rest/data/MinifyResource.java
@@ -44,8 +44,8 @@ public class MinifyResource {
 				url = URLDecoder.decode(url, "UTF-8");
                 TinyGov tinygov = urlManager.load(url);
                 if (tinygov == null) {
-					String encodedUrl = URLEncoder.encode(url, "UTF-8");
-					String minified = GoUsaGovUtils.minify(encodedUrl);
+                    String encodedUrl = URLEncoder.encode(url, "UTF-8");
+                    String minified = GoUsaGovUtils.minify(encodedUrl);
                     String short_http_url = GoUsaGovUtils.getUrlFromResponse(minified);
                     if (short_http_url == null) {
                         throw new Exception("Cannot get url from go.usa.gov");

--- a/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/rest/data/MinifyResource.java
+++ b/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/rest/data/MinifyResource.java
@@ -8,14 +8,15 @@ import gov.usgs.cida.coastalhazards.rest.data.util.HttpUtil;
 import gov.usgs.cida.utilities.gov.usa.go.GoUsaGovUtils;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
+import java.net.URLDecoder;
 import java.util.HashMap;
 import java.util.Map;
 
 import javax.annotation.security.PermitAll;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.commons.lang.StringUtils;
@@ -33,16 +34,17 @@ public class MinifyResource {
     private static TinyGovManager urlManager = new TinyGovManager();
 
 	@GET
-	@Path("/minify/{url:.*}")
+	@Path("/minify")
 	@Produces(MediaType.APPLICATION_JSON)
-	public Response minify(@PathParam("url") String url) {
+	public Response minify(@QueryParam("url") String url) {
 		Map<String, String> responseMap = new HashMap<String, String>();
 		Response response;
 		try {
 			if (StringUtils.isNotBlank(url)) {
+				url = URLDecoder.decode(url, "UTF-8");
                 TinyGov tinygov = urlManager.load(url);
                 if (tinygov == null) {
-                    String encodedUrl = URLEncoder.encode(url, "UTF-8");
+					String encodedUrl = URLEncoder.encode(url, "UTF-8");
                     String minified = GoUsaGovUtils.minify(encodedUrl);
                     String short_http_url = GoUsaGovUtils.getUrlFromResponse(minified);
                     if (short_http_url == null) {
@@ -79,60 +81,6 @@ public class MinifyResource {
 			responseMap.put("message", ex.getMessage());
 			response = Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(GsonUtil.getDefault().toJson(responseMap, HashMap.class)).build();
 		}
-		return response;
-	}
-
-	@GET
-	@Path("/expand/{url:.*}")
-	@Produces(MediaType.APPLICATION_JSON)
-	public Response expand(@PathParam("url") String url) {
-		Map<String, String> responseMap = new HashMap<String, String>();
-		Response response = null;
-		try {
-			if (StringUtils.isNotBlank(url)) {
-				String encodedUrl = URLEncoder.encode(url, "UTF-8");
-				response = Response.ok(GoUsaGovUtils.expand(encodedUrl)).build();
-			} else {
-				responseMap.put("message", "parameter 'url' may not be missing or blank");
-				response = Response.status(Response.Status.BAD_REQUEST)
-                        .entity(GsonUtil.getDefault().toJson(responseMap, HashMap.class)).build();
-			}
-		} catch (URISyntaxException ex) {
-			responseMap.put("message", ex.getMessage());
-			response = Response.status(Response.Status.BAD_REQUEST)
-                    .entity(GsonUtil.getDefault().toJson(responseMap, HashMap.class)).build();
-		} catch (Exception ex) { 
-			responseMap.put("message", ex.getMessage());
-			response = Response.status(Response.Status.INTERNAL_SERVER_ERROR)
-                    .entity(GsonUtil.getDefault().toJson(responseMap, HashMap.class)).build();
-		}
-		return response;
-	}
-
-	@GET
-	@Path("/clicks/{url:.*}")
-	@Produces(MediaType.APPLICATION_JSON)
-	public Response clicks(@PathParam("url") String url) {
-		Map<String, String> responseMap = new HashMap<String, String>();
-		Response response = null;
-		try {
-			if (StringUtils.isNotBlank(url)) {
-				String encodedUrl = URLEncoder.encode(url, "UTF-8");
-				response = Response.ok(GoUsaGovUtils.clicks(encodedUrl)).build();
-			} else {
-				responseMap.put("message", "parameter 'url' may not be missing or blank");
-				response = Response.status(Response.Status.BAD_REQUEST)
-                        .entity(GsonUtil.getDefault().toJson(responseMap, HashMap.class)).build();
-			}
-		} catch (URISyntaxException ex) {
-			responseMap.put("message", ex.getMessage());
-			response = Response.status(Response.Status.BAD_REQUEST)
-                    .entity(GsonUtil.getDefault().toJson(responseMap, HashMap.class)).build();
-		} catch (Exception ex) {
-			responseMap.put("message", ex.getMessage());
-			response = Response.status(Response.Status.INTERNAL_SERVER_ERROR)
-                    .entity(GsonUtil.getDefault().toJson(responseMap, HashMap.class)).build();
-		} 
 		return response;
 	}
 }

--- a/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/rest/data/MinifyResource.java
+++ b/coastal-hazards-portal/src/main/java/gov/usgs/cida/coastalhazards/rest/data/MinifyResource.java
@@ -45,7 +45,7 @@ public class MinifyResource {
                 TinyGov tinygov = urlManager.load(url);
                 if (tinygov == null) {
 					String encodedUrl = URLEncoder.encode(url, "UTF-8");
-                    String minified = GoUsaGovUtils.minify(encodedUrl);
+					String minified = GoUsaGovUtils.minify(encodedUrl);
                     String short_http_url = GoUsaGovUtils.getUrlFromResponse(minified);
                     if (short_http_url == null) {
                         throw new Exception("Cannot get url from go.usa.gov");

--- a/coastal-hazards-portal/src/main/webapp/js/cch/util/Util.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/util/Util.js
@@ -83,7 +83,7 @@ CCH.Util.Util = {
 		
 		// When we're not in a tutorial, go ahead and call the minify functionality
 		// on the back end
-		return $.ajax(CCH.CONFIG.contextPath + '/data/minifier/minify/' + location, {
+		return $.ajax(CCH.CONFIG.contextPath + '/data/minifier/minify?url=' + encodeURI(location), {
 			type: 'GET',
 			dataType: 'json'
 		});


### PR DESCRIPTION
…on submission.

Couldn't reproduce this locally, but I think I figured out the issue. I noticed that requests to minify URLs on Prod were being sent correctly such as:

`https://marine.usgs.gov/coastalchangehazardsportal/data/minifier/minify/https://marine.usgs.gov/coastalchangehazardsportal/ui/view/26f55f82a27e2147bcd513f78952bf637fa59e70`

However, they were then failing because the URL being submitted to GoUSA only had a single `/` after the `https:` despite the request to the portal having both. I tested this locally and my requests were passing through both `/`'s. What I think is happening is that either one of the proxies or the WAF or something is stripping out the second `/`. Since we were using a PathParam for this instead of a QueryParam it probably is interpreting the whole thing as more sub-paths of the URL instead of a parameter, so it sees `//` as a useless thing and just drops the 2nd `/`.

So this PR changes the Minification endpoint to accept a QueryParam instead of a PathParam and has the UI URIEncode the URL before sending it. Hopefully this will prevent the 2nd `/` from being stripped out during routing.

Additionally I think this will fix the other issue of the "View in Portal" button not working properly. The URL that button points to gets set by the result of the minification request. If the request fails, as it is currently doing on all deployed tiers, it re-send the original URL that was requested and the "View in Portal" button gets sent to that. Thus, because of the 2nd `/` getting stripped from the request, the response URL that gets set to the button is `https:/marine.usgs.gov/...` and I think the browser tries to fix that by assuming everything after `https:` is meant to be a sub-path of the current domain, so it ends up with `https://marine.usgs.gov/marine.usgs.gov/...`

So hopefully this should fix both of those issues, and the real underlying issue being buried within the routing somewhere would explain why this started happening out of nowhere without any changes from us (probably some new rule somewhere that strips the 2nd `/`).

I also removed the other two methods from the minifier endpoint because, as far as I could tell from searching the whole repo, they're never used anywhere. If I'm wrong about that though let me know and I can restore them.