### PR TITLE
(Mostly) fixed tweet buttons. Removed duplicate dependency from POM.

### DIFF
--- a/coastal-hazards-portal/pom.xml
+++ b/coastal-hazards-portal/pom.xml
@@ -198,12 +198,6 @@
 			<version>16.2</version>
 		</dependency>
 		
-		<dependency>
-			<groupId>gov.usgs.cida.coastalhazards</groupId>
-			<artifactId>ehcache-shaded</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		
 		<!-- this has to be after hibernate in the classpath :( -->
 		<dependency>
 			<groupId>javax</groupId>

--- a/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/ui/back/index.jsp
+++ b/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/ui/back/index.jsp
@@ -275,7 +275,8 @@
                                 </div>
                             </div>
                             <div class="modal-footer">
-                                <span id='twitter-button-span'></span>
+                                <span class="pull-right" id='twitter-button-span'></span>
+                                <img id="twitter-button-load" class="tweet-button-loading" src="<%=baseUrl%>/images/spinner/spinner2.gif" alt="loading twitter"/>
                                 <a href="#" class="btn btn-default"  data-dismiss="modal" aria-hidden="true">Close</a>
                             </div>
                         </div>

--- a/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/ui/back/index.jsp
+++ b/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/ui/back/index.jsp
@@ -276,7 +276,7 @@
                             </div>
                             <div class="modal-footer">
                                 <span class="pull-right" id='twitter-button-span'></span>
-                                <img id="twitter-button-load" class="tweet-button-loading" src="<%=baseUrl%>/images/spinner/spinner2.gif" alt="loading twitter"/>
+                                <img id="twitter-button-load" src="<%=baseUrl%>/images/spinner/spinner2.gif" alt="loading twitter"/>
                                 <a href="#" class="btn btn-default"  data-dismiss="modal" aria-hidden="true">Close</a>
                             </div>
                         </div>

--- a/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/ui/front/navigation-bar.jsp
+++ b/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/ui/front/navigation-bar.jsp
@@ -58,6 +58,7 @@
             </div>
             <div class="modal-footer">
 				<span class="pull-right" id='multi-card-twitter-button'></span>
+                <img id="multi-card-twitter-load-img" class="tweet-button-loading" src="${param['baseUrl']}/images/spinner/spinner2.gif" alt="loading twitter"/>
                 <a href="#" class="btn btn-default shareclosebutton"  data-dismiss="modal" aria-hidden="true">Close</a>
             </div>
         </div>

--- a/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/ui/front/navigation-bar.jsp
+++ b/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/ui/front/navigation-bar.jsp
@@ -58,7 +58,7 @@
             </div>
             <div class="modal-footer">
 				<span class="pull-right" id='multi-card-twitter-button'></span>
-                <img id="multi-card-twitter-load-img" styleClass="tweet-button-loading" src="${fn:escapeXml(param['baseUrl'])}/images/spinner/spinner2.gif" alt="loading twitter"/>
+                <img id="multi-card-twitter-load-img" src="${param['baseUrl']}/images/spinner/spinner2.gif" alt="loading twitter"/>
                 <a href="#" class="btn btn-default shareclosebutton"  data-dismiss="modal" aria-hidden="true">Close</a>
             </div>
         </div>

--- a/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/ui/front/navigation-bar.jsp
+++ b/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/ui/front/navigation-bar.jsp
@@ -58,7 +58,7 @@
             </div>
             <div class="modal-footer">
 				<span class="pull-right" id='multi-card-twitter-button'></span>
-                <img id="multi-card-twitter-load-img" class="tweet-button-loading" src="${param['baseUrl']}/images/spinner/spinner2.gif" alt="loading twitter"/>
+                <img id="multi-card-twitter-load-img" styleClass="tweet-button-loading" src="${fn:escapeXml(param['baseUrl'])}/images/spinner/spinner2.gif" alt="loading twitter"/>
                 <a href="#" class="btn btn-default shareclosebutton"  data-dismiss="modal" aria-hidden="true">Close</a>
             </div>
         </div>

--- a/coastal-hazards-portal/src/main/webapp/js/application/front/OnReady.js
+++ b/coastal-hazards-portal/src/main/webapp/js/application/front/OnReady.js
@@ -44,6 +44,7 @@ $(document).ready(function () {
 			shareModalId: 'modal-content-share',
 			shareUrlButtonId: 'modal-share-summary-url-button',
 			shareInputId: 'modal-share-summary-url-inputbox',
+			shareLoadingId: 'multi-card-twitter-load-img',
 			shareTwitterBtnId: 'multi-card-twitter-button',
 			helpModalId: 'helpModal',
 			helpModalBodyId: 'help-modal-body',

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/back/UI.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/back/UI.js
@@ -18,7 +18,7 @@ CCH.Objects.Back.UI = function (args) {
 	me.isSmall = function () {
 		return $(window).outerWidth() < me.magicResizeNumber;
 	};
-	me.DO_RETRY_TWEET_BUTTON = true;
+	me.TWEET_BUTTON_MAX_TRIES = 2;
 
 	me.init = function (args) {
 		me.$qrImage = $('#qr-code-img');
@@ -415,7 +415,7 @@ CCH.Objects.Back.UI = function (args) {
 		});
 	};
 
-	me.createTweetButton = function() {
+	me.createTweetButton = function(currentTry) {
 		twttr.widgets.createShareButton(
 			$('#modal-share-summary-url-inputbox').val(),
 			$('#twitter-button-span')[0],
@@ -432,14 +432,13 @@ CCH.Objects.Back.UI = function (args) {
 			setTimeout(function() {
 				if($('.twitter-share-button')[0].style.width !== "1px") {
 					$('#twitter-button-load').addClass('hidden');
-				} else if(me.DO_RETRY_TWEET_BUTTON) {
+				} else if(currentTry < me.TWEET_BUTTON_MAX_TRIES) {
 					$('#twitter-button-span').empty();
-					me.createTweetButton();
+					me.createTweetButton(currentTry + 1);
 				} else {
 					$('#twitter-button-load').addClass('hidden');
 					$('#twitter-button-span').html("Failed to load tweet button. Please close and try again.")
 				}
-				me.DO_RETRY_TWEET_BUTTON = false;
 			}, 200);
 		});
 	}
@@ -451,8 +450,7 @@ CCH.Objects.Back.UI = function (args) {
 		// Create Tweet button after modal animation (only if it doesn't exist)
 		if($('.twitter-share-button').length == 0) {
 			setTimeout(function() {
-				me.DO_RETRY_TWEET_BUTTON = true;
-				me.createTweetButton();
+				me.createTweetButton(1);
 			}, 300);
 		}
 	});

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/back/UI.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/back/UI.js
@@ -18,6 +18,7 @@ CCH.Objects.Back.UI = function (args) {
 	me.isSmall = function () {
 		return $(window).outerWidth() < me.magicResizeNumber;
 	};
+	me.DO_RETRY_TWEET_BUTTON = true;
 
 	me.init = function (args) {
 		me.$qrImage = $('#qr-code-img');
@@ -193,23 +194,9 @@ CCH.Objects.Back.UI = function (args) {
 
 			// Add the url to the input box
 			$shareInput.val(url);
-			// Highlight the entire input box
-			$shareInput.select();
+
 			// Enable the share button
 			$shareButton.removeClass('disabled');
-
-			twttr.widgets.createShareButton(
-					url,
-					$('#twitter-button-span')[0],
-					{
-						hashtags: 'USGS_CCH',
-						lang: 'en',
-						size: 'large',
-						dnt: true,
-						text: CCH.CONFIG.item.summary.tiny.text,
-						count: 'none'
-					}
-			);
 
 			twttr.events.bind('tweet', function () {
 				alertify.log('Your view has been tweeted. Thank you.');
@@ -427,6 +414,47 @@ CCH.Objects.Back.UI = function (args) {
 			}
 		});
 	};
+
+	me.createTweetButton = function() {
+		twttr.widgets.createShareButton(
+			$('#modal-share-summary-url-inputbox').val(),
+			$('#twitter-button-span')[0],
+			{
+				hashtags: 'USGS_CCH',
+				lang: 'en',
+				size: 'large',
+				dnt: true,
+				text: CCH.CONFIG.item.summary.tiny.text,
+				count: 'none'
+			}
+		).then(function() {
+			// Let widget render then verify that it is visible or retry
+			setTimeout(function() {
+				if($('.twitter-share-button')[0].style.width !== "1px") {
+					$('#twitter-button-load').addClass('hidden');
+				} else if(me.DO_RETRY_TWEET_BUTTON) {
+					$('#twitter-button-span').empty();
+					me.createTweetButton();
+				} else {
+					$('#twitter-button-load').addClass('hidden');
+					$('#twitter-button-span').html("Failed to load tweet button. Please close and try again.")
+				}
+				me.DO_RETRY_TWEET_BUTTON = false;
+			}, 200);
+		});
+	}
+
+	$('#modal-sharing-view').on('shown.bs.modal', function() {
+		// Highlight the entire input box
+		$('#modal-share-summary-url-inputbox').select();
+
+		// Create Tweet button after modal animation
+		if(me.DO_RETRY_TWEET_BUTTON) {
+			setTimeout(function() {
+				me.createTweetButton();
+			}, 300);
+		}
+	});
 
 	$(window).on({
 		'resize': function () {

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/back/UI.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/back/UI.js
@@ -448,9 +448,10 @@ CCH.Objects.Back.UI = function (args) {
 		// Highlight the entire input box
 		$('#modal-share-summary-url-inputbox').select();
 
-		// Create Tweet button after modal animation
-		if(me.DO_RETRY_TWEET_BUTTON) {
+		// Create Tweet button after modal animation (only if it doesn't exist)
+		if($('.twitter-share-button').length == 0) {
 			setTimeout(function() {
+				me.DO_RETRY_TWEET_BUTTON = true;
 				me.createTweetButton();
 			}, 300);
 		}

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/front/UI.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/front/UI.js
@@ -537,7 +537,7 @@ CCH.Objects.Front.UI = function (args) {
 		}
 	};
 
-	me.createTweetButton = function(retries) {
+	me.createTweetButton = function() {
 		twttr.widgets.createShareButton(
 			$('#' + me.SHARE_INPUT_ID).val(),
 			$('#' + me.SHARE_TWITTER_BUTTON_ID)[0],

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/front/UI.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/front/UI.js
@@ -26,6 +26,9 @@ CCH.Objects.Front.UI = function (args) {
 	me.SHARE_MODAL_ID = args.shareModalId;
 	me.SHARE_URL_BUTTON_ID = args.shareUrlButtonId;
 	me.SHARE_INPUT_ID = args.shareInputId;
+	me.SHARE_TWITTER_LOADING_ID = args.shareLoadingId;
+	me.SHARE_TITLE = "";
+	me.DO_RETRY_TWEET_BUTTON = true;
 	me.SHARE_TWITTER_BUTTON_ID = args.shareTwitterBtnId;
 	me.ITEMS_SLIDE_CONTAINER_ID = args.slideItemsContainerId;
 	me.BUCKET_SLIDE_CONTAINER_ID = args.slideBucketContainerId;
@@ -150,34 +153,13 @@ CCH.Objects.Front.UI = function (args) {
 				shareInput = $('#' + me.SHARE_INPUT_ID);
 
 			shareInput.val(url);
+			me.SHARE_TITLE = shareTitle || 'Check out my CCH View!';
 			
 			$('#' + me.SHARE_URL_BUTTON_ID).attr({
 				'href': url
 			}).removeClass('disabled');
-			
-			twttr.widgets.createShareButton(
-				url,
-				$('#' + me.SHARE_TWITTER_BUTTON_ID)[0],
-				{
-					hashtags: 'USGS_CCH',
-					lang: 'en',
-					size: 'large',
-					dnt: true,
-					text: shareTitle || 'Check out my CCH View!',
-					count: 'none'
-				}
-			);
-	
+
 			$('#' + me.SHARE_MODAL_ID).modal('show');
-			
-			twttr.events.bind('tweet', function () {
-				ga('send', 'event', {
-					'eventCategory': 'twitter',
-					'eventAction': 'tweeted',
-					'eventLabel': 'social events'
-				});
-				alertify.log('Your view has been tweeted. Thank you.');
-			});
 		};
 
 		CCH.Util.Util.getMinifiedEndpoint({
@@ -189,6 +171,8 @@ CCH.Objects.Front.UI = function (args) {
 		$('#' + me.SHARE_URL_BUTTON_ID).addClass('disabled');
 		$('#' + me.SHARE_INPUT_ID).val('');
 		$('#' + me.SHARE_TWITTER_BUTTON_ID).empty();
+		$('#' + me.SHARE_TWITTER_LOADING_ID).removeClass('hidden');
+		me.SHARE_TITLE = "";
 
 		args = args || {};
 
@@ -553,6 +537,35 @@ CCH.Objects.Front.UI = function (args) {
 		}
 	};
 
+	me.createTweetButton = function(retries) {
+		twttr.widgets.createShareButton(
+			$('#' + me.SHARE_INPUT_ID).val(),
+			$('#' + me.SHARE_TWITTER_BUTTON_ID)[0],
+			{
+				hashtags: 'USGS_CCH',
+				lang: 'en',
+				size: 'large',
+				dnt: true,
+				text: me.SHARE_TITLE,
+				count: 'none'
+			}
+		).then(function() {
+			// Let widget render then verify that it is visible or retry
+			setTimeout(function() {
+				if($('.twitter-share-button')[0].style.width !== "1px") {
+					$('#' + me.SHARE_TWITTER_LOADING_ID).addClass('hidden');
+				} else if(me.DO_RETRY_TWEET_BUTTON) {
+					$('#' + me.SHARE_TWITTER_BUTTON_ID).empty();
+					me.createTweetButton();
+				} else {
+					$('#' + me.SHARE_TWITTER_LOADING_ID).addClass('hidden');
+					$('#' + me.SHARE_TWITTER_BUTTON_ID).html("Failed to load tweet button. Please close and try again.")
+				}
+				me.DO_RETRY_TWEET_BUTTON = false;
+			}, 200);
+		});
+	}
+
 	// Do Bindings
 	$(window).on({
 		'cch.data.items.searched': me.itemsSearchedHandler,
@@ -569,6 +582,15 @@ CCH.Objects.Front.UI = function (args) {
 				me.windowResizeHandler();
 			}, 1);
 		}
+	});
+
+	twttr.events.bind('tweet', function () {
+		ga('send', 'event', {
+			'eventCategory': 'twitter',
+			'eventAction': 'tweeted',
+			'eventLabel': 'social events'
+		});
+		alertify.log('Your view has been tweeted. Thank you.');
 	});
 
 	$(me.combinedSearch).on({
@@ -606,6 +628,12 @@ CCH.Objects.Front.UI = function (args) {
 	// easier copying in mobile
 	$('#' + me.SHARE_MODAL_ID).on('shown.bs.modal', function () {
 		$('#' + me.SHARE_INPUT_ID).select();
+		me.DO_RETRY_TWEET_BUTTON = true;
+
+		// Wait a bit before creating widget to allow modal to animate
+		setTimeout(function() {
+			me.createTweetButton();
+		}, 300);
 	});
 
 	$(window).trigger('cch.ui.initialized');

--- a/coastal-hazards-portal/src/main/webapp/js/cch/objects/front/UI.js
+++ b/coastal-hazards-portal/src/main/webapp/js/cch/objects/front/UI.js
@@ -28,7 +28,7 @@ CCH.Objects.Front.UI = function (args) {
 	me.SHARE_INPUT_ID = args.shareInputId;
 	me.SHARE_TWITTER_LOADING_ID = args.shareLoadingId;
 	me.SHARE_TITLE = "";
-	me.DO_RETRY_TWEET_BUTTON = true;
+	me.TWEET_BUTTON_MAX_TRIES = 2;
 	me.SHARE_TWITTER_BUTTON_ID = args.shareTwitterBtnId;
 	me.ITEMS_SLIDE_CONTAINER_ID = args.slideItemsContainerId;
 	me.BUCKET_SLIDE_CONTAINER_ID = args.slideBucketContainerId;
@@ -537,7 +537,7 @@ CCH.Objects.Front.UI = function (args) {
 		}
 	};
 
-	me.createTweetButton = function() {
+	me.createTweetButton = function(currentTry) {
 		twttr.widgets.createShareButton(
 			$('#' + me.SHARE_INPUT_ID).val(),
 			$('#' + me.SHARE_TWITTER_BUTTON_ID)[0],
@@ -554,14 +554,13 @@ CCH.Objects.Front.UI = function (args) {
 			setTimeout(function() {
 				if($('.twitter-share-button')[0].style.width !== "1px") {
 					$('#' + me.SHARE_TWITTER_LOADING_ID).addClass('hidden');
-				} else if(me.DO_RETRY_TWEET_BUTTON) {
+				} else if(currentTry < me.TWEET_BUTTON_MAX_TRIES) {
 					$('#' + me.SHARE_TWITTER_BUTTON_ID).empty();
-					me.createTweetButton();
+					me.createTweetButton(currentTry + 1);
 				} else {
 					$('#' + me.SHARE_TWITTER_LOADING_ID).addClass('hidden');
 					$('#' + me.SHARE_TWITTER_BUTTON_ID).html("Failed to load tweet button. Please close and try again.")
 				}
-				me.DO_RETRY_TWEET_BUTTON = false;
 			}, 200);
 		});
 	}
@@ -628,11 +627,10 @@ CCH.Objects.Front.UI = function (args) {
 	// easier copying in mobile
 	$('#' + me.SHARE_MODAL_ID).on('shown.bs.modal', function () {
 		$('#' + me.SHARE_INPUT_ID).select();
-		me.DO_RETRY_TWEET_BUTTON = true;
 
 		// Wait a bit before creating widget to allow modal to animate
 		setTimeout(function() {
-			me.createTweetButton();
+			me.createTweetButton(1);
 		}, 300);
 	});
 

--- a/coastal-hazards-portal/src/main/webapp/less/back/back.less
+++ b/coastal-hazards-portal/src/main/webapp/less/back/back.less
@@ -282,7 +282,7 @@ html, body {
     right:90px;
 }
 
-.tweet-button-loading {
+#twitter-button-load {
     max-width: 20px;
     margin-right: 20px;
 }

--- a/coastal-hazards-portal/src/main/webapp/less/back/back.less
+++ b/coastal-hazards-portal/src/main/webapp/less/back/back.less
@@ -282,6 +282,11 @@ html, body {
     right:90px;
 }
 
+.tweet-button-loading {
+    max-width: 20px;
+	margin-right: 20px;
+}
+
 /* Section headers */
 .section-header {
 	font-weight: 600;

--- a/coastal-hazards-portal/src/main/webapp/less/back/back.less
+++ b/coastal-hazards-portal/src/main/webapp/less/back/back.less
@@ -284,7 +284,7 @@ html, body {
 
 .tweet-button-loading {
     max-width: 20px;
-	margin-right: 20px;
+    margin-right: 20px;
 }
 
 /* Section headers */

--- a/coastal-hazards-portal/src/main/webapp/less/front/application.less
+++ b/coastal-hazards-portal/src/main/webapp/less/front/application.less
@@ -198,6 +198,7 @@ html, body {
     right: 90px;
     bottom: 10px;
 }
+
 .tweet-button-loading {
     max-width: 20px;
 	margin-right: 20px;

--- a/coastal-hazards-portal/src/main/webapp/less/front/application.less
+++ b/coastal-hazards-portal/src/main/webapp/less/front/application.less
@@ -199,7 +199,7 @@ html, body {
     bottom: 10px;
 }
 
-.tweet-button-loading {
+#multi-card-twitter-load-img {
     max-width: 20px;
     margin-right: 20px;
 }

--- a/coastal-hazards-portal/src/main/webapp/less/front/application.less
+++ b/coastal-hazards-portal/src/main/webapp/less/front/application.less
@@ -198,6 +198,10 @@ html, body {
     right: 90px;
     bottom: 10px;
 }
+.tweet-button-loading {
+    max-width: 20px;
+	margin-right: 20px;
+}
 
 .shareclosebutton {
     padding:4px 12px;

--- a/coastal-hazards-portal/src/main/webapp/less/front/application.less
+++ b/coastal-hazards-portal/src/main/webapp/less/front/application.less
@@ -201,7 +201,7 @@ html, body {
 
 .tweet-button-loading {
     max-width: 20px;
-	margin-right: 20px;
+    margin-right: 20px;
 }
 
 .shareclosebutton {


### PR DESCRIPTION
- The twitter widget API that we use for generating buttons was updated at some point to have the buttons consider the size of the Div that they're rendering into before being created.
- When we created the tweet buttons we did so within hidden modal divs, and this resulted in tweet buttons being created with a width/height of 1px.
- Moving tweet button creation to after the div is created fixed the sizing issue, however there were still times (perhaps 1/10) when the button would render with the width/height of 1px. Not sure why that happens because the div is fully rendered and should be sized correctly. Assume it's some sort of weirdness with the widget API or something. To fix that I added a retry that checks the size of the button after rendering and if it's 1px then it re-creates it.
- If for some reason that still fails (which happens occasionally) then it shows an error message telling the user to reload the modal and try again.
- I also added a loading spinner while the tweet buttons are waiting to be created to illustrate that something should show up eventually.
- On the "front" UI we were also adding an event listener to show an alertify dialog when the user tweets something every time the share button was clicked, which resulted in multiple alerts popping up if the share button was clicked multiple times. I fixed that by moving the listener creation outside of the modal click handler function.