### PR TITLE
Fix an issue where publish/item would redirect endlessly when a query…

### DIFF
--- a/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/publish/item/index.jsp
+++ b/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/publish/item/index.jsp
@@ -83,7 +83,17 @@
     <head>
         <script type="text/javascript">
             if (window.location.pathname.indexOf("/item/") === -1) {
-                window.location = window.location.href + "/";
+                // Find query param separator
+                var argIndex = window.location.href.indexOf("?");
+                    argIndex = argIndex === -1 ? window.location.href.length : argIndex;
+                
+                // Split location into path + params and add "/" to end of path
+                var reqPath = window.location.href.substr(0, argIndex);
+                    reqPath = reqPath.endsWith("/") ? reqPath : reqPath + "/";
+                var reqParams = window.location.href.substr(argIndex, window.location.href.length);
+
+                // Navigate Window
+                window.location = reqPath + reqParams;
             }
         </script>
         <jsp:include page="../../ui/common/meta-tags.jsp">

--- a/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/publish/item/index.jsp
+++ b/coastal-hazards-portal/src/main/webapp/WEB-INF/jsp/publish/item/index.jsp
@@ -82,18 +82,12 @@
 <html>
     <head>
         <script type="text/javascript">
-            if (window.location.pathname.indexOf("/item/") === -1) {
-                // Find query param separator
-                var argIndex = window.location.href.indexOf("?");
-                    argIndex = argIndex === -1 ? window.location.href.length : argIndex;
-                
-                // Split location into path + params and add "/" to end of path
-                var reqPath = window.location.href.substr(0, argIndex);
-                    reqPath = reqPath.endsWith("/") ? reqPath : reqPath + "/";
-                var reqParams = window.location.href.substr(argIndex, window.location.href.length);
+            // Ensure URL has trailing slash (before query params)
+            var url = new URL(window.location.href)
+            url.pathname = url.pathname.endsWith('/') ? url.pathname : url.pathname + '/'
 
-                // Navigate Window
-                window.location = reqPath + reqParams;
+            if(url.toString() !== window.location.href) {
+                window.location = url.toString()
             }
         </script>
         <jsp:include page="../../ui/common/meta-tags.jsp">


### PR DESCRIPTION
… param included a / and the path did not.

We never saw this issue happen before because the old login method didn't include a redirect with query params to this page. This old JS snippet apparently assumed that there would be no query params, but that assumption is no longer valid.