### PR TITLE
Add dependency scanning profile to project parent POM.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -554,4 +554,93 @@
 			</plugins>
 		</pluginManagement>
 	</build>
+	<profiles>
+        <profile>
+            <id>security-scan</id>
+            <properties>
+                <owasp.dependency.check.version>5.2.4</owasp.dependency.check.version>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.owasp</groupId>
+                        <artifactId>dependency-check-maven</artifactId>
+                        <version>${owasp.dependency.check.version}</version>
+                        <executions>
+                            <execution>
+                                <configuration>
+                                    <!--
+                                    plugin config documentation
+                                    https://jeremylong.github.io/DependencyCheck/dependency-check-maven/configuration.html
+                                    -->
+                                    <formats>HTML,XML</formats>
+                                    <outputDirectory>target/dependency-check</outputDirectory>
+                                    <autoUpdate>true</autoUpdate>
+                                    <cveValidForHours>24</cveValidForHours>
+                                    <jarAnalyzerEnabled>true</jarAnalyzerEnabled>
+                                    <retireJsAnalyzerEnabled>true</retireJsAnalyzerEnabled>
+
+                                    <!-- disable analyzer that has a known stability problem https://github.com/jeremylong/DependencyCheck/issues/1908 -->
+                                    <ossindexAnalyzerEnabled>false</ossindexAnalyzerEnabled>
+
+                                    <!-- explicitly disable irrelevant analyzers to improve performance -->
+
+                                    <archiveAnalyzerEnabled>false</archiveAnalyzerEnabled> <!-- This scans all types of archives. We mostly care about JARs and WARs. The jarAnalyzer handles those -->
+                                    <centralAnalyzerEnabled>false</centralAnalyzerEnabled> <!-- the ossindexAnalyzer is sufficient -->
+                                    <nexusAnalyzerEnabled>false</nexusAnalyzerEnabled> <!-- the ossindexAnalyzer is sufficient -->
+                                    <artifactoryAnalyzerEnabled>false</artifactoryAnalyzerEnabled> <!-- the ossindexAnalyzer is sufficient -->
+
+                                    <!-- none of the following languages apply -->
+                                    <pyDistributionAnalyzerEnabled>false</pyDistributionAnalyzerEnabled>
+                                    <pyPackageAnalyzerEnabled>false</pyPackageAnalyzerEnabled>
+                                    <rubygemsAnalyzerEnabled>false</rubygemsAnalyzerEnabled>
+                                    <opensslAnalyzerEnabled>false</opensslAnalyzerEnabled>
+                                    <cmakeAnalyzerEnabled>false</cmakeAnalyzerEnabled>
+                                    <autoconfAnalyzerEnabled>false</autoconfAnalyzerEnabled>
+                                    <composerAnalyzerEnabled>false</composerAnalyzerEnabled>
+                                    <nodeAnalyzerEnabled>false</nodeAnalyzerEnabled>
+                                    <nodeAuditAnalyzerEnabled>false</nodeAuditAnalyzerEnabled>
+                                    <nuspecAnalyzerEnabled>false</nuspecAnalyzerEnabled>
+                                    <nugetconfAnalyzerEnabled>false</nugetconfAnalyzerEnabled>
+                                    <cocoapodsAnalyzerEnabled>false</cocoapodsAnalyzerEnabled>
+                                    <bundleAuditAnalyzerEnabled>false</bundleAuditAnalyzerEnabled>
+                                    <swiftPackageManagerAnalyzerEnabled>false</swiftPackageManagerAnalyzerEnabled>
+                                    <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
+                                    <!-- Add a suppression file to the root of the project called 
+									dependency-check-suppression.xml and uncomment the following line 
+									to enable suppressions of specific false-postive vulnerabilties. -->
+									<!--
+                                    <suppressionFile>dependency-check-suppression.xml</suppressionFile>
+									-->
+									<!-- More info on analyzers:
+                                    	 https://jeremylong.github.io/DependencyCheck/analyzers/index.html
+                                    -->
+                                </configuration>
+								<phase>test</phase>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+            <reporting>
+                <plugins>
+                    <plugin>
+                        <groupId>org.owasp</groupId>
+                        <artifactId>dependency-check-maven</artifactId>
+                        <version>${owasp.dependency.check.version}</version>
+                        <reportSets>
+                            <reportSet>
+                                <reports>
+                                    <report>aggregate</report>
+                                </reports>
+                            </reportSet>
+                        </reportSets>
+                    </plugin>
+                </plugins>
+            </reporting>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
This will run during the `test` phase of a maven build when you have enabled the `security-scan` maven profile. The results are output into the `target/dependency-check` directory of each sub-project in the CCH repo.

Example build commands:

Normal build command with no security scan: `mvn clean package` (This is essentially what the Docker version of the build runs)

Build command with security scan: `mvn -Psecurity-scan clean package`

Note that if you've only been building the portal via Docker you will need to install JDK (the portal uses JDK 8) and maven onto your host machine to run this scan because the version of the build that happens within Docker won't run the scan and although we could configure it to do so it wouldn't be easy to extract the resultant HTML reports out of the container for viewing and the scan would have to re-download the full vulnerability database each time it ran which would significantly add to the build time for the portal during local development.

If you try to run this build with JDK 11 as your default JDK (if your system JAVA_HOME env points to JDK 11 instead of 8) you will see some errors during the build and it won't finish. So you can run it like this to guarantee it uses JDK 8:

`export JAVA_HOME=<path to JDK 8> && mvn -Psecurity-scan clean package`